### PR TITLE
feat(sdrs): add examples

### DIFF
--- a/apis/sdrs/v1beta1/zz_replicationpair_types.go
+++ b/apis/sdrs/v1beta1/zz_replicationpair_types.go
@@ -70,11 +70,11 @@ type ReplicationPairParameters struct {
 	// +kubebuilder:validation:Optional
 	VolumeID *string `json:"volumeId,omitempty" tf:"volume_id,omitempty"`
 
-	// Reference to a BlockStorageVolume	 in evs to populate volumeId.
+	// Reference to a BlockStorageVolume in evs to populate volumeId.
 	// +kubebuilder:validation:Optional
 	VolumeIDRef *v1.Reference `json:"volumeIdRef,omitempty" tf:"-"`
 
-	// Selector for a BlockStorageVolume	 in evs to populate volumeId.
+	// Selector for a BlockStorageVolume in evs to populate volumeId.
 	// +kubebuilder:validation:Optional
 	VolumeIDSelector *v1.Selector `json:"volumeIdSelector,omitempty" tf:"-"`
 }

--- a/config/sdrs/config.go
+++ b/config/sdrs/config.go
@@ -8,9 +8,11 @@ import (
 
 // Configure configures individual resources by adding custom ResourceConfigurators.
 func Configure(p *config.Provider) {
+
+	// flexibleengine_sdrs_drill_v1
+	// https://registry.terraform.io/providers/FlexibleEngineCloud/flexibleengine/latest/docs/resources/sdrs_drill_v1
 	p.AddResourceConfigurator("flexibleengine_sdrs_drill_v1", func(r *config.Resource) {
 
-		// group_id
 		r.References["group_id"] = config.Reference{
 			Type: "ProtectionGroup",
 		}
@@ -19,9 +21,10 @@ func Configure(p *config.Provider) {
 		}
 
 	})
-	p.AddResourceConfigurator("flexibleengine_sdrs_protectedinstance_v1", func(r *config.Resource) {
 
-		// group_id
+	// flexibleengine_sdrs_protectedinstance_v1
+	// https://registry.terraform.io/providers/FlexibleEngineCloud/flexibleengine/latest/docs/resources/sdrs_protectedinstance_v1
+	p.AddResourceConfigurator("flexibleengine_sdrs_protectedinstance_v1", func(r *config.Resource) {
 		r.References["group_id"] = config.Reference{
 			Type: "ProtectionGroup",
 		}
@@ -31,13 +34,18 @@ func Configure(p *config.Provider) {
 		r.References["primary_subnet_id"] = config.Reference{
 			Type: tools.GenerateType("vpc", "VPCSubnet"),
 		}
-
 	})
+
+	// flexibleengine_sdrs_protectiongroup_v1
+	// https://registry.terraform.io/providers/FlexibleEngineCloud/flexibleengine/latest/docs/resources/sdrs_protectiongroup_v1
 	p.AddResourceConfigurator("flexibleengine_sdrs_protectiongroup_v1", func(r *config.Resource) {
 		r.References["source_vpc_id"] = config.Reference{
 			Type: tools.GenerateType("vpc", "VPC"),
 		}
 	})
+
+	// flexibleengine_sdrs_replication_attach_v1
+	// https://registry.terraform.io/providers/FlexibleEngineCloud/flexibleengine/latest/docs/resources/sdrs_replication_attach_v1
 	p.AddResourceConfigurator("flexibleengine_sdrs_replication_attach_v1", func(r *config.Resource) {
 		r.References["instance_id"] = config.Reference{
 			Type: "ProtectedInstance",
@@ -46,12 +54,15 @@ func Configure(p *config.Provider) {
 			Type: "ReplicationPair",
 		}
 	})
+
+	// flexibleengine_sdrs_replication_pair_v1
+	// https://registry.terraform.io/providers/FlexibleEngineCloud/flexibleengine/latest/docs/resources/sdrs_replication_pair_v1
 	p.AddResourceConfigurator("flexibleengine_sdrs_replication_pair_v1", func(r *config.Resource) {
 		r.References["group_id"] = config.Reference{
 			Type: "ProtectionGroup",
 		}
 		r.References["volume_id"] = config.Reference{
-			Type: tools.GenerateType("evs", "BlockStorageVolume	"),
+			Type: tools.GenerateType("evs", "BlockStorageVolume"),
 		}
 	})
 

--- a/examples/evs/blockstoragevolume.yaml
+++ b/examples/evs/blockstoragevolume.yaml
@@ -12,3 +12,4 @@ spec:
     name: example-evs-blockstoragevolume
     size: 3
     cascade: true
+    availabilityZone: eu-west-0a

--- a/examples/sdrs/drill.yaml
+++ b/examples/sdrs/drill.yaml
@@ -1,0 +1,17 @@
+apiVersion: sdrs.flexibleengine.upbound.io/v1beta1
+kind: Drill
+metadata:
+  annotations:
+    meta.upbound.io/example-id: sdrs/v1beta1/drill
+  labels:
+    testing.upbound.io/example-name: example_sdrs_drill
+  name: example-sdrs-drill
+spec:
+  forProvider:
+    drillVpcIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example_sdrs_drill_vpc
+    groupIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example_sdrs_protectiongroup
+    name: example-sdrs-drill

--- a/examples/sdrs/drill.yaml.extra
+++ b/examples/sdrs/drill.yaml.extra
@@ -1,0 +1,31 @@
+apiVersion: vpc.flexibleengine.upbound.io/v1beta1
+kind: VPC
+metadata:
+  annotations:
+    meta.upbound.io/example-id: vpc/v1beta1/vpc
+  labels:
+    testing.upbound.io/example-name: example_sdrs_drill_vpc
+  name: example-sdrs-drill-vpc
+spec:
+  forProvider:
+    name: "example-sdrs-drill-vpc"
+    cidr: "192.168.96.0/20"
+---
+apiVersion: vpc.flexibleengine.upbound.io/v1beta1
+kind: VPCSubnet
+metadata:
+  annotations:
+    meta.upbound.io/example-id: vpc/v1beta1/vpcsubnet
+  labels:
+    testing.upbound.io/example-name: example_sdrs_drill_subnet
+  name: example-sdrs-drill-subnet
+spec:
+  forProvider:
+    cidr: "192.168.100.0/24"
+    gatewayIp: "192.168.100.254"
+    name: "example-sdrs-drill-subnet"
+    vpcIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example_sdrs_drill_vpc
+    primaryDns: "100.125.0.41"
+    secondaryDns: "100.126.0.41"

--- a/examples/sdrs/protectedinstance.yaml
+++ b/examples/sdrs/protectedinstance.yaml
@@ -1,0 +1,20 @@
+apiVersion: sdrs.flexibleengine.upbound.io/v1beta1
+kind: ProtectedInstance
+metadata:
+  annotations:
+    meta.upbound.io/example-id: sdrs/v1beta1/protectedinstance
+  labels:
+    testing.upbound.io/example-name: example_sdrs_instance
+  name: example-sdrs-instance
+spec:
+  forProvider:
+    description: test description
+    deleteTargetServer: true
+    deleteTargetEIP: true
+    groupIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example_sdrs_protectiongroup
+    name: example-sdrs-instance
+    serverIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example_sdrs_instance_extra

--- a/examples/sdrs/protectedinstance.yaml.extra
+++ b/examples/sdrs/protectedinstance.yaml.extra
@@ -1,0 +1,42 @@
+apiVersion: ecs.flexibleengine.upbound.io/v1beta1
+kind: Instance
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ecs/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: example_sdrs_instance_extra
+  name: example-sdrs-instance-extra
+spec:
+  forProvider:
+    flavorId: t2.micro
+    imageId: "121d32ef-80d5-41f8-a940-f227a33d2b2a"
+    availabilityZone: "eu-west-0a"
+    keyPairSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example_keypair
+    name: example-instance
+    network:
+      - uuidSelector:
+          matchLabels:
+            testing.upbound.io/example-name: example_subnet
+    securityGroups:
+      - default
+    tags:
+      foo: bar
+      this: that
+    schedulerHints:
+      - groupSelector:
+          matchLabels:
+            testing.upbound.io/example-name: example_servergroup
+---
+apiVersion: ecs.flexibleengine.upbound.io/v1beta1
+kind: KeyPair
+metadata:
+  annotations:
+    meta.upbound.io/example-id: ecs/v1beta1/keypair
+  labels:
+    testing.upbound.io/example-name: example_keypair
+  name: example-keypair
+spec:
+  forProvider:
+    publicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7CnfqUmkT7aVeJnnCzSXRIMX547BnWRD4V+5SJHnY9zyvi3lC0fLlyZ6MAosdBo77KLMGI45VRHGPwiqmimF6L/O4VG/Ku8xfBXVV0EGilEicbyzvyG26H0O2JDSbIN8AwgDC89Zla2NhQoh7XogK311pkEjK9q2/cVaeeY27S5053FPeFCKedw6q3Dv/naJQbGDqgkShybpccG0jloGalCmDXWqlvSCqj2TGsdj49AKkX5RaygHkploTv8pUyLwmE/bEZV8NLPsp0lS+ziyIZoGqLMCndrFN5P4z2mPVpzTZ/o3Ppv8YKD/BQdg+bwGl6uQuSe5Mcx+eXBlU/Lw1 Generated-by-Nova"

--- a/examples/sdrs/protectiongroup.yaml
+++ b/examples/sdrs/protectiongroup.yaml
@@ -1,0 +1,19 @@
+apiVersion: sdrs.flexibleengine.upbound.io/v1beta1
+kind: ProtectionGroup
+metadata:
+  annotations:
+    meta.upbound.io/example-id: sdrs/v1beta1/protectiongroup
+  labels:
+    testing.upbound.io/example-name: example_sdrs_protectiongroup
+  name: example-sdrs-protectiongroup
+spec:
+  forProvider:
+    description: test description
+    domainId: 96443ca2-6a66-4231-848e-2ace986556a7
+    drType: migration
+    name: example-sdrs-protectiongroup
+    sourceAvailabilityZone: eu-west-0a
+    targetAvailabilityZone: eu-west-0b
+    sourceVpcIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example_vpc

--- a/examples/sdrs/replicationattach.yaml
+++ b/examples/sdrs/replicationattach.yaml
@@ -1,0 +1,17 @@
+apiVersion: sdrs.flexibleengine.upbound.io/v1beta1
+kind: ReplicationAttach
+metadata:
+  annotations:
+    meta.upbound.io/example-id: sdrs/v1beta1/replicationattach
+  labels:
+    testing.upbound.io/example-name: example_sdrs_replicationattach
+  name: example-sdrs-replicationattach
+spec:
+  forProvider:
+    device: /dev/vdb
+    instanceIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example_sdrs_instance
+    replicationIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example_sdrs_replicationpair

--- a/examples/sdrs/replicationpair.yaml
+++ b/examples/sdrs/replicationpair.yaml
@@ -1,0 +1,18 @@
+apiVersion: sdrs.flexibleengine.upbound.io/v1beta1
+kind: ReplicationPair
+metadata:
+  annotations:
+    meta.upbound.io/example-id: sdrs/v1beta1/replicationpair
+  labels:
+    testing.upbound.io/example-name: example_sdrs_replicationpair
+  name: example-sdrs-replicationpair
+spec:
+  forProvider:
+    description: test description
+    groupIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example_sdrs_protectiongroup
+    name: example-sdrs-replicationpair
+    volumeIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example_evs_blockstoragevolume

--- a/package/crds/sdrs.flexibleengine.upbound.io_replicationpairs.yaml
+++ b/package/crds/sdrs.flexibleengine.upbound.io_replicationpairs.yaml
@@ -174,8 +174,8 @@ spec:
                       creates a new pair.
                     type: string
                   volumeIdRef:
-                    description: "Reference to a BlockStorageVolume\t in evs to populate
-                      volumeId."
+                    description: Reference to a BlockStorageVolume in evs to populate
+                      volumeId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -209,8 +209,8 @@ spec:
                     - name
                     type: object
                   volumeIdSelector:
-                    description: "Selector for a BlockStorageVolume\t in evs to populate
-                      volumeId."
+                    description: Selector for a BlockStorageVolume in evs to populate
+                      volumeId.
                     properties:
                       matchControllerRef:
                         description: MatchControllerRef ensures an object with the


### PR DESCRIPTION
### Description of your changes


I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```
NAME                                                    READY   SYNCED   EXTERNAL-NAME     AGE
keypair.ecs.flexibleengine.upbound.io/example-keypair   True    True    REDACTED   28m

NAME                                                                 READY   SYNCED   EXTERNAL-NAME                          AGE
instance.ecs.flexibleengine.upbound.io/example-sdrs-instance-extra   True    True     REDACTED   39m

NAME                                                            READY   SYNCED   EXTERNAL-NAME                          AGE
servergroup.ecs.flexibleengine.upbound.io/example-servergroup   True    True     REDACTED   4h18m

NAME                                                                              READY   SYNCED   EXTERNAL-NAME                          AGE
blockstoragevolume.evs.flexibleengine.upbound.io/example-evs-blockstoragevolume   True    True     REDACTED   9m24s

NAME                                                                          READY   SYNCED   EXTERNAL-NAME                          AGE
replicationpair.sdrs.flexibleengine.upbound.io/example-sdrs-replicationpair   True    True     REDACTED   2m19s

NAME                                                                          READY   SYNCED   EXTERNAL-NAME                          AGE
protectiongroup.sdrs.flexibleengine.upbound.io/example-sdrs-protectiongroup   True    True     REDACTED   39m

NAME                                                                              READY   SYNCED   EXTERNAL-NAME                                                               AGE
replicationattach.sdrs.flexibleengine.upbound.io/example-sdrs-replicationattach   True    True     REDACTED   2m20s

NAME                                                                     READY   SYNCED   EXTERNAL-NAME                          AGE
protectedinstance.sdrs.flexibleengine.upbound.io/example-sdrs-instance   True    True     REDACTED   39m

NAME                                                                READY   SYNCED   EXTERNAL-NAME                          AGE
vpcsubnet.vpc.flexibleengine.upbound.io/example-subnet              True    True     REDACTED   4h18m
```