### PR TITLE
feat(rds): Add rds single instance example

### DIFF
--- a/examples/rds/account.yaml
+++ b/examples/rds/account.yaml
@@ -1,0 +1,18 @@
+apiVersion: rds.flexibleengine.upbound.io/v1beta1
+kind: Account
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/account
+  labels:
+    testing.upbound.io/example-name: example_rds_account
+  name: example-rds-account
+spec:
+  forProvider:
+    instanceIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example_rds_instance
+    name: example-rds-account
+    passwordSecretRef:
+      key: example-rds-key
+      name: example-rds-secret
+      namespace: crossplane-system

--- a/examples/rds/database.yaml
+++ b/examples/rds/database.yaml
@@ -1,0 +1,15 @@
+apiVersion: rds.flexibleengine.upbound.io/v1beta1
+kind: Database
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/database
+  labels:
+    testing.upbound.io/example-name: example_rds_database
+  name: example-rds-database
+spec:
+  forProvider:
+    characterSet: utf8
+    instanceIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example_rds_instance
+    name: example-rds-database

--- a/examples/rds/databaseprivilege.yaml
+++ b/examples/rds/databaseprivilege.yaml
@@ -1,0 +1,17 @@
+apiVersion: rds.flexibleengine.upbound.io/v1beta1
+kind: DatabasePrivilege
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/databaseprivilege
+  labels:
+    testing.upbound.io/example-name: example_rds_databaseprivilege
+  name: example-rds-databaseprivilege
+spec:
+  forProvider:
+    dbName: example-rds-database
+    instanceIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example_rds_instance
+    users:
+    - name: example-rds-account
+      readonly: true

--- a/examples/rds/instance.yaml
+++ b/examples/rds/instance.yaml
@@ -1,0 +1,39 @@
+apiVersion: rds.flexibleengine.upbound.io/v1beta1
+kind: Instance
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/instance
+  labels:
+    testing.upbound.io/example-name: example_rds_instance
+  name: example-rds-instance
+spec:
+  forProvider:
+    availabilityZone:
+      - eu-west-0a
+      - eu-west-0b
+    backupStrategy:
+      - keepDays: 1
+        startTime: 08:00-09:00
+    db:
+    - passwordSecretRef:
+        key: example-rds-key
+        name: example-rds-secret
+        namespace: crossplane-system
+      port: 3306
+      type: MySQL
+      version: "5.7"
+    flavor: rds.mysql.s3.medium.4.ha
+    haReplicationMode: async
+    name: example-rds-instance
+    securityGroupIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example_secgroup
+    subnetIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example_subnet
+    volume:
+    - size: 100
+      type: COMMON
+    vpcIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example_vpc

--- a/examples/rds/instance.yaml.extra
+++ b/examples/rds/instance.yaml.extra
@@ -1,0 +1,19 @@
+apiVersion: vpc.flexibleengine.upbound.io/v1beta1
+kind: SecurityGroupRule
+metadata:
+  annotations:
+    meta.upbound.io/example-id: vpc/v1beta1/securitygrouprule
+  labels:
+    testing.upbound.io/example-name: example_secgroup_rule_rds
+  name: example-secgroup-rule-rds
+spec:
+  forProvider:
+    direction: ingress
+    ethertype: IPv4
+    portRangeMax: 3306
+    portRangeMin: 3306
+    protocol: tcp
+    remoteIpPrefix: 0.0.0.0/0
+    securityGroupIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example_secgroup

--- a/examples/rds/instance_secret.yaml
+++ b/examples/rds/instance_secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    testing.upbound.io/example-name: example_rds_secret
+  name: example-rds-secret
+  namespace: crossplane-system
+type: Opaque
+stringData:
+  example-rds-key: SuperS3cr3tP4ssw0rd

--- a/examples/rds/parametergroup.yaml
+++ b/examples/rds/parametergroup.yaml
@@ -1,0 +1,21 @@
+apiVersion: rds.flexibleengine.upbound.io/v1beta1
+kind: ParameterGroup
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/parametergroup
+  labels:
+    testing.upbound.io/example-name: pg_1
+  name: pg-1
+spec:
+  forProvider:
+    datastore:
+    - type: mysql
+      version: "5.6"
+    description: description_1
+    name: pg_1
+    values:
+      autocommit: "OFF"
+      max_connections: "10"
+
+---
+

--- a/examples/rds/parametergroup.yaml
+++ b/examples/rds/parametergroup.yaml
@@ -4,18 +4,15 @@ metadata:
   annotations:
     meta.upbound.io/example-id: rds/v1beta1/parametergroup
   labels:
-    testing.upbound.io/example-name: pg_1
-  name: pg-1
+    testing.upbound.io/example-name: example_rds_parametergroup
+  name: example-rds-parametergroup
 spec:
   forProvider:
     datastore:
     - type: mysql
-      version: "5.6"
+      version: "5.7"
     description: description_1
-    name: pg_1
+    name: example-rds-parametergroup
     values:
       autocommit: "OFF"
       max_connections: "10"
-
----
-

--- a/examples/rds/readreplica.yaml
+++ b/examples/rds/readreplica.yaml
@@ -1,0 +1,18 @@
+apiVersion: rds.flexibleengine.upbound.io/v1beta1
+kind: ReadReplica
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/readreplica
+  labels:
+    testing.upbound.io/example-name: example_rds_readreplica
+  name: example-rds-readreplica
+spec:
+  forProvider:
+    availabilityZone: eu-west-0c
+    flavor: rds.mysql.s3.medium.4.rr
+    name: example-rds-readreplica
+    replicaOfIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example_rds_instance
+    volume:
+    - type: ULTRAHIGH


### PR DESCRIPTION
### Description of your changes

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
```
NAME                                                    READY   SYNCED   EXTERNAL-NAME     AGE
keypair.ecs.flexibleengine.upbound.io/example-keypair   True    True     example-keypair   4d

NAME                                                                        READY   SYNCED   EXTERNAL-NAME                                           AGE
databaseprivilege.rds.flexibleengine.upbound.io/exemple-databaseprivilege   True    True     05f95286dcb8496fb3a7dfa0c8ba4a8ain01/example-database   118m

NAME                                                    READY   SYNCED   EXTERNAL-NAME                                          AGE
account.rds.flexibleengine.upbound.io/example-account   True    True     05f95286dcb8496fb3a7dfa0c8ba4a8ain01/example-account   123m

NAME                                                            READY   SYNCED   EXTERNAL-NAME                          AGE
readreplica.rds.flexibleengine.upbound.io/example-readreplica   True    True     7dd4dc33af81480db2c907bf8a552c5cin01   75m

NAME                                                      READY   SYNCED   EXTERNAL-NAME                                           AGE
database.rds.flexibleengine.upbound.io/example-database   True    True     05f95286dcb8496fb3a7dfa0c8ba4a8ain01/example-database   80m

NAME                                                          READY   SYNCED   EXTERNAL-NAME                          AGE
instance.rds.flexibleengine.upbound.io/example-rds-instance   True    True     05f95286dcb8496fb3a7dfa0c8ba4a8ain01   168m

NAME                                                                  READY   SYNCED   EXTERNAL-NAME                          AGE
parametergroup.rds.flexibleengine.upbound.io/example-parametergroup   True    True     c06b8bc3647c4460b87b95fdb75dbab3pr01   103m

NAME                                                           READY   SYNCED   EXTERNAL-NAME                          AGE
securitygroup.vpc.flexibleengine.upbound.io/example-secgroup   True    True     f005b7d6-5bb9-4d2c-a25b-7959314075dd   25h

NAME                                            READY   SYNCED   EXTERNAL-NAME                          AGE
vpc.vpc.flexibleengine.upbound.io/example-vpc   True    True     13532b25-8836-46d7-bc57-14ace2bd47df   5d6h

NAME                                                     READY   SYNCED   EXTERNAL-NAME                          AGE
vpcsubnet.vpc.flexibleengine.upbound.io/example-subnet   True    True     2e044c75-c21f-4bad-9c04-c85a431f536e   5d6h

NAME                                                                    READY   SYNCED   EXTERNAL-NAME                          AGE
securitygrouprule.vpc.flexibleengine.upbound.io/example-secgroup-rule   True    True     1098e4ed-72b2-4efe-add3-5ef2472672db   6h5m
```

