### PR TITLE
fix(vpc): fix subnet_id attribute

### DIFF
--- a/config/external_name.go
+++ b/config/external_name.go
@@ -388,7 +388,7 @@ var ExternalNameConfigs = map[string]config.ExternalName{
 	"flexibleengine_vpc_subnet_v1": {
 		SetIdentifierArgumentFn: config.NopSetIdentifierArgument,
 		GetExternalNameFn: func(tfstate map[string]any) (string, error) {
-			if id, ok := tfstate["subnet_id"].(string); ok && id != "" {
+			if id, ok := tfstate["ipv4_subnet_id"].(string); ok && id != "" {
 				return id, nil
 			}
 			return "", errors.New("cannot find id in tfstate")


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane Felxible Engine provider!
-->

### Description of your changes
The `subnet_id` attribute is deprecated and replaced by `ipv4_subnet_id` in the VPC subnet resource.
`GetExternalNameFn` should use the `ipv4_subnet_id` attribute instead of `subnet_id`.

Fixes #60 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```
NAME                                                      READY   SYNCED   EXTERNAL-NAME                          AGE
instance.ecs.flexibleengine.upbound.io/example-instance   True    True    REDACTED   2m29s

NAME                                                            READY   SYNCED   EXTERNAL-NAME                          AGE
servergroup.ecs.flexibleengine.upbound.io/example-servergroup   True    True     REDACTED   2m28s

NAME                                                    READY   SYNCED   EXTERNAL-NAME     AGE
keypair.ecs.flexibleengine.upbound.io/example-keypair   True    True     REDACTED   2m29s

NAME                                                     READY   SYNCED   EXTERNAL-NAME                          AGE
vpcsubnet.vpc.flexibleengine.upbound.io/example-subnet   True    True     REDACTED   54m

NAME                                                           READY   SYNCED   EXTERNAL-NAME                          AGE
securitygroup.vpc.flexibleengine.upbound.io/example-secgroup   True    True     REDACTED   3m14s

NAME                                            READY   SYNCED   EXTERNAL-NAME                          AGE
vpc.vpc.flexibleengine.upbound.io/example-vpc   True    True     REDACTED   54m
```