### PR TITLE
ci: add PR size labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,28 @@
+name: labeler
+
+on: [pull_request]
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    name: Label the PR size
+    steps:
+      - uses: codelytv/pr-size-labeler@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_label: 'size/xs'
+          xs_max_size: '10'
+          s_label: 'size/s'
+          s_max_size: '100'
+          m_label: 'size/m'
+          m_max_size: '500'
+          l_label: 'size/l'
+          l_max_size: '1000'
+          xl_label: 'size/xl'
+          fail_if_xl: 'false'
+          message_if_xl: >
+            This PR exceeds the recommended size of 1000 lines.
+            Please make sure you are NOT addressing multiple issues with one PR.
+            Note this PR might be rejected due to its size.
+          github_api_url: 'api.github.com'
+          files_to_ignore: ''


### PR DESCRIPTION
Add Github Action on pull_request to labelise with the PR size :

|  Name  |  Description  |
|---|---|
|  `size/xs`  |  Denotes a PR that changes 0-10 lines.  |
|  `size/s`  |  Denotes a PR that changes 11-100 lines.  |
|  `size/m`  |  Denotes a PR that changes 101-500 lines.  |
|  `size/l`  |  Denotes a PR that changes 501-1000 lines.  |
|  `size/xl`  |  Denotes a PR that changes 1001+ lines.  |
