### PR TITLE
feat(main)!: move tenantName to ProviderConfig.spec

### DIFF
--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -21,6 +21,8 @@ type ProviderConfigSpec struct {
 	DomainName string `json:"domainName"`
 	// Insecure
 	Insecure bool `json:"insecure,omitempty"`
+	// TenantName
+	TenantName string `json:"tenantName,omitempty"`
 }
 
 // ProviderCredentials required to authenticate.

--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -18,11 +18,15 @@ type ProviderConfigSpec struct {
 	// Region
 	Region string `json:"region"`
 	// DomainName
-	DomainName string `json:"domainName"`
-	// Insecure
-	Insecure bool `json:"insecure,omitempty"`
+	DomainName string `json:"domainName,omitempty"`
+	// DomainID
+	DomainID string `json:"domainId,omitempty"`
 	// TenantName
 	TenantName string `json:"tenantName,omitempty"`
+	// TenantID
+	TenantID string `json:"tenantId,omitempty"`
+	// Insecure
+	Insecure bool `json:"insecure,omitempty"`
 }
 
 // ProviderCredentials required to authenticate.

--- a/internal/clients/flexibleengine.go
+++ b/internal/clients/flexibleengine.go
@@ -29,9 +29,11 @@ const (
 	// provider config
 	keyRegion     = "region"
 	keyDomainName = "domain_name"
+	keyDomainID   = "domain_id"
 	keyAccessKey  = "access_key"
 	keySecretKey  = "secret_key"
 	keyTenantName = "tenant_name"
+	keyTenantID   = "tenant_id"
 	keyInsecure   = "insecure"
 )
 
@@ -74,8 +76,10 @@ func TerraformSetupBuilder(version, providerSource, providerVersion string) terr
 		ps.Configuration = map[string]interface{}{
 			keyRegion:     pc.Spec.Region,
 			keyDomainName: pc.Spec.DomainName,
+			keyDomainID:   pc.Spec.DomainID,
 			keyInsecure:   pc.Spec.Insecure,
 			keyTenantName: pc.Spec.TenantName,
+			keyTenantID:   pc.Spec.TenantID,
 		}
 		if v, ok := creds[keyAccessKey]; ok {
 			ps.Configuration[keyAccessKey] = v

--- a/internal/clients/flexibleengine.go
+++ b/internal/clients/flexibleengine.go
@@ -75,15 +75,13 @@ func TerraformSetupBuilder(version, providerSource, providerVersion string) terr
 			keyRegion:     pc.Spec.Region,
 			keyDomainName: pc.Spec.DomainName,
 			keyInsecure:   pc.Spec.Insecure,
+			keyTenantName: pc.Spec.TenantName,
 		}
 		if v, ok := creds[keyAccessKey]; ok {
 			ps.Configuration[keyAccessKey] = v
 		}
 		if v, ok := creds[keySecretKey]; ok {
 			ps.Configuration[keySecretKey] = v
-		}
-		if v, ok := creds[keyTenantName]; ok {
-			ps.Configuration[keyTenantName] = v
 		}
 		return ps, nil
 	}

--- a/package/crds/flexibleengine.upbound.io_providerconfigs.yaml
+++ b/package/crds/flexibleengine.upbound.io_providerconfigs.yaml
@@ -109,6 +109,9 @@ spec:
               region:
                 description: Region
                 type: string
+              tenantName:
+                description: TenantName
+                type: string
             required:
             - credentials
             - domainName

--- a/package/crds/flexibleengine.upbound.io_providerconfigs.yaml
+++ b/package/crds/flexibleengine.upbound.io_providerconfigs.yaml
@@ -100,6 +100,9 @@ spec:
                 required:
                 - source
                 type: object
+              domainId:
+                description: DomainID
+                type: string
               domainName:
                 description: DomainName
                 type: string
@@ -109,12 +112,14 @@ spec:
               region:
                 description: Region
                 type: string
+              tenantId:
+                description: TenantID
+                type: string
               tenantName:
                 description: TenantName
                 type: string
             required:
             - credentials
-            - domainName
             - region
             type: object
           status:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Felxible Engine provider!
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Add tenantName to ProviderConfig.spec instead of credentials in Secret.

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Create a ProviderConfig with TenantName : 
```yaml
apiVersion: flexibleengine.upbound.io/v1beta1
kind: ProviderConfig
metadata:
  name: default
spec:
  region: eu-west-0
  domainName: OCB000xxxx
  tenantName: eu-west-0_test
  credentials:
    source: Secret
    secretRef:
      name: example-creds
      namespace: crossplane-system
      key: credentials
```

Create a simple VPC and ensure it is running : 
```shell
NAME                                            READY   SYNCED   EXTERNAL-NAME                          AGE
vpc.vpc.flexibleengine.upbound.io/example-vpc   True    True     0eb7cc09-d948-4548-b831-243e8d665012   70s
```

Check in the Flexible Engin console that the VPC was created in the right tenant :white_check_mark: 
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->