### PR TITLE
refactor: change all extractor to unique function

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,44 @@
+version: v1
+
+labels:
+  - label: "feature"
+    sync: true
+    matcher:
+      title: "^feat.*"
+      commits: "^feat.*"
+
+  - label: "bugfix"
+    sync: true
+    matcher:
+      title: "^fix.*"
+      commits: "^fix.*"
+
+  - label: "documentation"
+    sync: true
+    matcher:
+      title: "^docs.*"
+      commits: "^docs.*"
+
+  - label: "ci"
+    sync: true
+    matcher:
+      title: "^ci.*"
+      commits: "^ci.*"
+
+  - label: "refactor"
+    sync: true
+    matcher:
+      title: "^refactor.*"
+      commits: "^refactor.*"
+
+  - label: "chore"
+    sync: true
+    matcher:
+      title: "^chore.*"
+      commits: "^chore.*"
+
+  - label: "dependencies"
+    sync: true
+    matcher:
+      files:
+        any: [ "go.mod" ]

--- a/.github/workflows/issue_triage.yml
+++ b/.github/workflows/issue_triage.yml
@@ -1,4 +1,4 @@
-name: Issue Labeler
+name: Issue Triage
 
 on:
   issues:

--- a/.github/workflows/pr_triage.yml
+++ b/.github/workflows/pr_triage.yml
@@ -1,14 +1,23 @@
-name: Pull Request Treatment
+name: PR Triage
 
 on: 
-  pull_request_target:
+  pull_request:
     types: [ opened, edited, reopened, synchronize ]
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   labeler:
     runs-on: ubuntu-latest
-    name: Label the PR size
+    name: Labeler
     steps:
+      - uses: fuxingloh/multi-labeler@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          config-path: .github/labeler.yml
+
       - uses: codelytv/pr-size-labeler@v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -24,7 +33,7 @@ jobs:
           fail_if_xl: 'false'
 
   validate-title:
-    name: Validate PR title
+    name: Validate title
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5

--- a/apis/agd/v1beta1/zz_generated.resolvers.go
+++ b/apis/agd/v1beta1/zz_generated.resolvers.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	v1beta1 "github.com/FrangipaneTeam/provider-flexibleengine/apis/eip/v1beta1"
 	v1beta11 "github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1"
-	common "github.com/FrangipaneTeam/provider-flexibleengine/config/common"
+	tools "github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -260,7 +260,7 @@ func (mg *Instance) ResolveReferences(ctx context.Context, c client.Reader) erro
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.SubnetID),
-		Extract:      common.IDExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "id"),
 		Reference:    mg.Spec.ForProvider.SubnetIDRef,
 		Selector:     mg.Spec.ForProvider.SubnetIDSelector,
 		To: reference.To{

--- a/apis/agd/v1beta1/zz_instance_types.go
+++ b/apis/agd/v1beta1/zz_instance_types.go
@@ -145,7 +145,7 @@ type InstanceParameters struct {
 	// instance. Changing this will create a new APIG dedicated instance resource.
 	// The ID of the VPC subnet used to create the dedicated instance.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/as/v1beta1/zz_generated.resolvers.go
+++ b/apis/as/v1beta1/zz_generated.resolvers.go
@@ -13,7 +13,7 @@ import (
 	v1beta1 "github.com/FrangipaneTeam/provider-flexibleengine/apis/ims/v1beta1"
 	v1beta14 "github.com/FrangipaneTeam/provider-flexibleengine/apis/smn/v1beta1"
 	v1beta13 "github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1"
-	common "github.com/FrangipaneTeam/provider-flexibleengine/config/common"
+	tools "github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -112,7 +112,7 @@ func (mg *Group) ResolveReferences(ctx context.Context, c client.Reader) error {
 	for i3 := 0; i3 < len(mg.Spec.ForProvider.Networks); i3++ {
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Networks[i3].ID),
-			Extract:      common.IDExtractor(),
+			Extract:      tools.ExtractorParamPathfunc(true, "id"),
 			Reference:    mg.Spec.ForProvider.Networks[i3].IDRef,
 			Selector:     mg.Spec.ForProvider.Networks[i3].IDSelector,
 			To: reference.To{

--- a/apis/as/v1beta1/zz_group_types.go
+++ b/apis/as/v1beta1/zz_group_types.go
@@ -202,7 +202,7 @@ type NetworksParameters struct {
 
 	// The network UUID.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +kubebuilder:validation:Optional
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 

--- a/apis/bms/v1beta1/zz_generated.resolvers.go
+++ b/apis/bms/v1beta1/zz_generated.resolvers.go
@@ -10,7 +10,7 @@ import (
 	v1beta11 "github.com/FrangipaneTeam/provider-flexibleengine/apis/ecs/v1beta1"
 	v1beta1 "github.com/FrangipaneTeam/provider-flexibleengine/apis/ims/v1beta1"
 	v1beta12 "github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1"
-	common "github.com/FrangipaneTeam/provider-flexibleengine/config/common"
+	tools "github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -42,7 +42,7 @@ func (mg *Server) ResolveReferences(ctx context.Context, c client.Reader) error 
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.ImageName),
-		Extract:      common.ImageNameExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(false, "image_name"),
 		Reference:    mg.Spec.ForProvider.ImageNameRef,
 		Selector:     mg.Spec.ForProvider.ImageNameSelector,
 		To: reference.To{
@@ -93,7 +93,7 @@ func (mg *Server) ResolveReferences(ctx context.Context, c client.Reader) error 
 	for i3 := 0; i3 < len(mg.Spec.ForProvider.Network); i3++ {
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Network[i3].UUID),
-			Extract:      common.IDExtractor(),
+			Extract:      tools.ExtractorParamPathfunc(true, "id"),
 			Reference:    mg.Spec.ForProvider.Network[i3].UUIDRef,
 			Selector:     mg.Spec.ForProvider.Network[i3].UUIDSelector,
 			To: reference.To{
@@ -110,7 +110,7 @@ func (mg *Server) ResolveReferences(ctx context.Context, c client.Reader) error 
 	}
 	mrsp, err = r.ResolveMultiple(ctx, reference.MultiResolutionRequest{
 		CurrentValues: reference.FromPtrValues(mg.Spec.ForProvider.SecurityGroups),
-		Extract:       common.NameExtractor(),
+		Extract:       tools.ExtractorParamPathfunc(false, "name"),
 		References:    mg.Spec.ForProvider.SecurityGroupsRefs,
 		Selector:      mg.Spec.ForProvider.SecurityGroupsSelector,
 		To: reference.To{

--- a/apis/bms/v1beta1/zz_server_types.go
+++ b/apis/bms/v1beta1/zz_server_types.go
@@ -92,7 +92,7 @@ type NetworkParameters struct {
 	// The network UUID to
 	// attach to the bms server. Changing this creates a new bms server.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +kubebuilder:validation:Optional
 	UUID *string `json:"uuid,omitempty" tf:"uuid,omitempty"`
 
@@ -178,7 +178,7 @@ type ServerParameters struct {
 	// The name of the
 	// desired image for the bms server. Changing this creates a new bms server.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/ims/v1beta1.Image
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.ImageNameExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(false, "image_name")
 	// +kubebuilder:validation:Optional
 	ImageName *string `json:"imageName,omitempty" tf:"image_name,omitempty"`
 
@@ -229,7 +229,7 @@ type ServerParameters struct {
 	// to associate with the bms server. Changing this results in adding/removing
 	// security groups from the existing bms server.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.SecurityGroup
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.NameExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(false, "name")
 	// +kubebuilder:validation:Optional
 	SecurityGroups []*string `json:"securityGroups,omitempty" tf:"security_groups,omitempty"`
 

--- a/apis/cce/v1beta1/zz_cluster_types.go
+++ b/apis/cce/v1beta1/zz_cluster_types.go
@@ -114,7 +114,7 @@ type ClusterParameters struct {
 
 	// EIP address of the cluster.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/eip/v1beta1.EIP
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.AddressExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "address")
 	// +kubebuilder:validation:Optional
 	EIP *string `json:"eip,omitempty" tf:"eip,omitempty"`
 
@@ -174,7 +174,7 @@ type ClusterParameters struct {
 	// The ID of the VPC Subnet used to create the node.
 	// Changing this parameter will create a new cluster resource.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/cce/v1beta1/zz_generated.resolvers.go
+++ b/apis/cce/v1beta1/zz_generated.resolvers.go
@@ -11,7 +11,7 @@ import (
 	v1beta1 "github.com/FrangipaneTeam/provider-flexibleengine/apis/eip/v1beta1"
 	v1beta12 "github.com/FrangipaneTeam/provider-flexibleengine/apis/kms/v1beta1"
 	v1beta11 "github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1"
-	common "github.com/FrangipaneTeam/provider-flexibleengine/config/common"
+	tools "github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -78,7 +78,7 @@ func (mg *Cluster) ResolveReferences(ctx context.Context, c client.Reader) error
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.EIP),
-		Extract:      common.AddressExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "address"),
 		Reference:    mg.Spec.ForProvider.EIPRef,
 		Selector:     mg.Spec.ForProvider.EIPSelector,
 		To: reference.To{
@@ -110,7 +110,7 @@ func (mg *Cluster) ResolveReferences(ctx context.Context, c client.Reader) error
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.SubnetID),
-		Extract:      common.IDExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "id"),
 		Reference:    mg.Spec.ForProvider.SubnetIDRef,
 		Selector:     mg.Spec.ForProvider.SubnetIDSelector,
 		To: reference.To{
@@ -219,7 +219,7 @@ func (mg *Node) ResolveReferences(ctx context.Context, c client.Reader) error {
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.SubnetID),
-		Extract:      common.IDExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "id"),
 		Reference:    mg.Spec.ForProvider.SubnetIDRef,
 		Selector:     mg.Spec.ForProvider.SubnetIDSelector,
 		To: reference.To{
@@ -295,7 +295,7 @@ func (mg *NodePool) ResolveReferences(ctx context.Context, c client.Reader) erro
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.SubnetID),
-		Extract:      common.IDExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "id"),
 		Reference:    mg.Spec.ForProvider.SubnetIDRef,
 		Selector:     mg.Spec.ForProvider.SubnetIDSelector,
 		To: reference.To{

--- a/apis/cce/v1beta1/zz_node_types.go
+++ b/apis/cce/v1beta1/zz_node_types.go
@@ -214,7 +214,7 @@ type NodeParameters struct {
 	// Specifies the ID of the VPC Subnet to which the NIC belongs.
 	// Changing this parameter will create a new resource.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/cce/v1beta1/zz_nodepool_types.go
+++ b/apis/cce/v1beta1/zz_nodepool_types.go
@@ -180,7 +180,7 @@ type NodePoolParameters struct {
 	// The ID of the VPC Subnet to which the NIC belongs.
 	// Changing this parameter will create a new resource.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/cse/v1beta1/zz_generated.resolvers.go
+++ b/apis/cse/v1beta1/zz_generated.resolvers.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	v1beta1 "github.com/FrangipaneTeam/provider-flexibleengine/apis/eip/v1beta1"
 	v1beta11 "github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1"
-	common "github.com/FrangipaneTeam/provider-flexibleengine/config/common"
+	tools "github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -66,7 +66,7 @@ func (mg *MicroserviceEngine) ResolveReferences(ctx context.Context, c client.Re
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.NetworkID),
-		Extract:      common.IDExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "id"),
 		Reference:    mg.Spec.ForProvider.NetworkIDRef,
 		Selector:     mg.Spec.ForProvider.NetworkIDSelector,
 		To: reference.To{

--- a/apis/cse/v1beta1/zz_microserviceengine_types.go
+++ b/apis/cse/v1beta1/zz_microserviceengine_types.go
@@ -107,7 +107,7 @@ type MicroserviceEngineParameters struct {
 	// Specifies the ID of VPC the subnet to which the dedicated microservice
 	// engine belongs. Changing this will create a new engine.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +kubebuilder:validation:Optional
 	NetworkID *string `json:"networkId,omitempty" tf:"network_id,omitempty"`
 

--- a/apis/dcs/v1beta1/zz_generated.resolvers.go
+++ b/apis/dcs/v1beta1/zz_generated.resolvers.go
@@ -8,7 +8,7 @@ package v1beta1
 import (
 	"context"
 	v1beta1 "github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1"
-	common "github.com/FrangipaneTeam/provider-flexibleengine/config/common"
+	tools "github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,7 +23,7 @@ func (mg *Instance) ResolveReferences(ctx context.Context, c client.Reader) erro
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.NetworkID),
-		Extract:      common.IDExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "id"),
 		Reference:    mg.Spec.ForProvider.NetworkIDRef,
 		Selector:     mg.Spec.ForProvider.NetworkIDSelector,
 		To: reference.To{

--- a/apis/dcs/v1beta1/zz_instance_types.go
+++ b/apis/dcs/v1beta1/zz_instance_types.go
@@ -138,7 +138,7 @@ type InstanceParameters struct {
 
 	// Specifies the ID of the VPC subnet. Changing this creates a new instance.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +kubebuilder:validation:Optional
 	NetworkID *string `json:"networkId,omitempty" tf:"network_id,omitempty"`
 

--- a/apis/dds/v1beta1/zz_generated.resolvers.go
+++ b/apis/dds/v1beta1/zz_generated.resolvers.go
@@ -8,7 +8,7 @@ package v1beta1
 import (
 	"context"
 	v1beta1 "github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1"
-	common "github.com/FrangipaneTeam/provider-flexibleengine/config/common"
+	tools "github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -91,7 +91,7 @@ func (mg *Instance) ResolveReferences(ctx context.Context, c client.Reader) erro
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.SubnetID),
-		Extract:      common.IDExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "id"),
 		Reference:    mg.Spec.ForProvider.SubnetIDRef,
 		Selector:     mg.Spec.ForProvider.SubnetIDSelector,
 		To: reference.To{

--- a/apis/dds/v1beta1/zz_instance_types.go
+++ b/apis/dds/v1beta1/zz_instance_types.go
@@ -160,7 +160,7 @@ type InstanceParameters struct {
 
 	// Specifies the ID of the VPC Subnet. Changing this creates a new instance.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/dedicatedelb/v1beta1/zz_generated.resolvers.go
+++ b/apis/dedicatedelb/v1beta1/zz_generated.resolvers.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	v1beta1 "github.com/FrangipaneTeam/provider-flexibleengine/apis/eip/v1beta1"
 	v1beta11 "github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1"
-	common "github.com/FrangipaneTeam/provider-flexibleengine/config/common"
+	tools "github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -163,7 +163,7 @@ func (mg *LoadBalancer) ResolveReferences(ctx context.Context, c client.Reader) 
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.IPv6NetworkID),
-		Extract:      common.IDExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "id"),
 		Reference:    mg.Spec.ForProvider.IPv6NetworkIDRef,
 		Selector:     mg.Spec.ForProvider.IPv6NetworkIDSelector,
 		To: reference.To{

--- a/apis/dedicatedelb/v1beta1/zz_loadbalancer_types.go
+++ b/apis/dedicatedelb/v1beta1/zz_loadbalancer_types.go
@@ -108,7 +108,7 @@ type LoadBalancerParameters struct {
 	// The network on which to allocate the loadbalancer's ipv6 address.
 	// the ID of the subnet where the load balancer resides
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +kubebuilder:validation:Optional
 	IPv6NetworkID *string `json:"ipv6NetworkId,omitempty" tf:"ipv6_network_id,omitempty"`
 

--- a/apis/dms/v1beta1/zz_generated.resolvers.go
+++ b/apis/dms/v1beta1/zz_generated.resolvers.go
@@ -8,7 +8,7 @@ package v1beta1
 import (
 	"context"
 	v1beta1 "github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1"
-	common "github.com/FrangipaneTeam/provider-flexibleengine/config/common"
+	tools "github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,7 +23,7 @@ func (mg *KafkaInstance) ResolveReferences(ctx context.Context, c client.Reader)
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.NetworkID),
-		Extract:      common.IDExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "id"),
 		Reference:    mg.Spec.ForProvider.NetworkIDRef,
 		Selector:     mg.Spec.ForProvider.NetworkIDSelector,
 		To: reference.To{

--- a/apis/dms/v1beta1/zz_kafkainstance_types.go
+++ b/apis/dms/v1beta1/zz_kafkainstance_types.go
@@ -132,7 +132,7 @@ type KafkaInstanceParameters struct {
 	// Specifies the ID of a VPC subnet.
 	// Changing this creates a new instance resource.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +kubebuilder:validation:Optional
 	NetworkID *string `json:"networkId,omitempty" tf:"network_id,omitempty"`
 

--- a/apis/dws/v1beta1/zz_cluster_types.go
+++ b/apis/dws/v1beta1/zz_cluster_types.go
@@ -96,7 +96,7 @@ type ClusterParameters struct {
 
 	// The ID of the VPC Subnet, which is used for configuring cluster network.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/dws/v1beta1/zz_generated.resolvers.go
+++ b/apis/dws/v1beta1/zz_generated.resolvers.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	v1beta1 "github.com/FrangipaneTeam/provider-flexibleengine/apis/eip/v1beta1"
 	v1beta11 "github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1"
-	common "github.com/FrangipaneTeam/provider-flexibleengine/config/common"
+	tools "github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -58,7 +58,7 @@ func (mg *Cluster) ResolveReferences(ctx context.Context, c client.Reader) error
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.SubnetID),
-		Extract:      common.IDExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "id"),
 		Reference:    mg.Spec.ForProvider.SubnetIDRef,
 		Selector:     mg.Spec.ForProvider.SubnetIDSelector,
 		To: reference.To{

--- a/apis/ecs/v1beta1/zz_generated.resolvers.go
+++ b/apis/ecs/v1beta1/zz_generated.resolvers.go
@@ -11,6 +11,7 @@ import (
 	v1beta11 "github.com/FrangipaneTeam/provider-flexibleengine/apis/ims/v1beta1"
 	v1beta12 "github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1"
 	common "github.com/FrangipaneTeam/provider-flexibleengine/config/common"
+	tools "github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -83,7 +84,7 @@ func (mg *Instance) ResolveReferences(ctx context.Context, c client.Reader) erro
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.ImageName),
-		Extract:      common.ImageNameExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(false, "image_name"),
 		Reference:    mg.Spec.ForProvider.ImageNameRef,
 		Selector:     mg.Spec.ForProvider.ImageNameSelector,
 		To: reference.To{
@@ -116,7 +117,7 @@ func (mg *Instance) ResolveReferences(ctx context.Context, c client.Reader) erro
 	for i3 := 0; i3 < len(mg.Spec.ForProvider.Network); i3++ {
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Network[i3].UUID),
-			Extract:      common.IDExtractor(),
+			Extract:      tools.ExtractorParamPathfunc(true, "id"),
 			Reference:    mg.Spec.ForProvider.Network[i3].UUIDRef,
 			Selector:     mg.Spec.ForProvider.Network[i3].UUIDSelector,
 			To: reference.To{

--- a/apis/ecs/v1beta1/zz_instance_types.go
+++ b/apis/ecs/v1beta1/zz_instance_types.go
@@ -162,7 +162,7 @@ type InstanceParameters struct {
 	// The name of the
 	// desired image for the server. Changing this creates a new server.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/ims/v1beta1.Image
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.ImageNameExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(false, "image_name")
 	// +kubebuilder:validation:Optional
 	ImageName *string `json:"imageName,omitempty" tf:"image_name,omitempty"`
 
@@ -274,7 +274,7 @@ type NetworkParameters struct {
 	// The network UUID to
 	// attach to the server. Changing this creates a new server.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +kubebuilder:validation:Optional
 	UUID *string `json:"uuid,omitempty" tf:"uuid,omitempty"`
 

--- a/apis/eip/v1beta1/zz_eipassociate_types.go
+++ b/apis/eip/v1beta1/zz_eipassociate_types.go
@@ -35,7 +35,7 @@ type EIPAssociateParameters struct {
 	// Specifies the ID of the VPC Subnet to which the fixed_ip belongs.
 	// It is mandatory when fixed_ip is set. Changing this creates a new resource.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +kubebuilder:validation:Optional
 	NetworkID *string `json:"networkId,omitempty" tf:"network_id,omitempty"`
 
@@ -63,7 +63,7 @@ type EIPAssociateParameters struct {
 
 	// Specifies the EIP address to associate. Changing this creates a new resource.
 	// +crossplane:generate:reference:type=EIP
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.AddressExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "address")
 	// +kubebuilder:validation:Optional
 	PublicIP *string `json:"publicIp,omitempty" tf:"public_ip,omitempty"`
 

--- a/apis/eip/v1beta1/zz_generated.resolvers.go
+++ b/apis/eip/v1beta1/zz_generated.resolvers.go
@@ -8,7 +8,7 @@ package v1beta1
 import (
 	"context"
 	v1beta1 "github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1"
-	common "github.com/FrangipaneTeam/provider-flexibleengine/config/common"
+	tools "github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,7 +23,7 @@ func (mg *EIPAssociate) ResolveReferences(ctx context.Context, c client.Reader) 
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.NetworkID),
-		Extract:      common.IDExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "id"),
 		Reference:    mg.Spec.ForProvider.NetworkIDRef,
 		Selector:     mg.Spec.ForProvider.NetworkIDSelector,
 		To: reference.To{
@@ -55,7 +55,7 @@ func (mg *EIPAssociate) ResolveReferences(ctx context.Context, c client.Reader) 
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.PublicIP),
-		Extract:      common.AddressExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "address"),
 		Reference:    mg.Spec.ForProvider.PublicIPRef,
 		Selector:     mg.Spec.ForProvider.PublicIPSelector,
 		To: reference.To{

--- a/apis/fgs/v1beta1/zz_function_types.go
+++ b/apis/fgs/v1beta1/zz_function_types.go
@@ -168,7 +168,7 @@ type FunctionParameters struct {
 
 	// Specifies the network ID of subnet.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +kubebuilder:validation:Optional
 	NetworkID *string `json:"networkId,omitempty" tf:"network_id,omitempty"`
 

--- a/apis/fgs/v1beta1/zz_generated.resolvers.go
+++ b/apis/fgs/v1beta1/zz_generated.resolvers.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	v1beta1 "github.com/FrangipaneTeam/provider-flexibleengine/apis/iam/v1beta1"
 	v1beta11 "github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1"
-	common "github.com/FrangipaneTeam/provider-flexibleengine/config/common"
+	tools "github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,7 +40,7 @@ func (mg *Function) ResolveReferences(ctx context.Context, c client.Reader) erro
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.NetworkID),
-		Extract:      common.IDExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "id"),
 		Reference:    mg.Spec.ForProvider.NetworkIDRef,
 		Selector:     mg.Spec.ForProvider.NetworkIDSelector,
 		To: reference.To{

--- a/apis/lts/v1beta1/zz_generated.resolvers.go
+++ b/apis/lts/v1beta1/zz_generated.resolvers.go
@@ -8,7 +8,7 @@ package v1beta1
 import (
 	"context"
 	v1beta1 "github.com/FrangipaneTeam/provider-flexibleengine/apis/ecs/v1beta1"
-	common "github.com/FrangipaneTeam/provider-flexibleengine/config/common"
+	tools "github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -81,7 +81,7 @@ func (mg *VPCFlowLog) ResolveReferences(ctx context.Context, c client.Reader) er
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.ResourceID),
-		Extract:      common.NetworkPortIDExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "network", "0", "port"),
 		Reference:    mg.Spec.ForProvider.ResourceIDRef,
 		Selector:     mg.Spec.ForProvider.ResourceIDSelector,
 		To: reference.To{

--- a/apis/lts/v1beta1/zz_vpcflowlog_types.go
+++ b/apis/lts/v1beta1/zz_vpcflowlog_types.go
@@ -70,7 +70,7 @@ type VPCFlowLogParameters struct {
 	// Specifies the network port ID.
 	// Changing this creates a new VPC flow log.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/ecs/v1beta1.Instance
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.NetworkPortIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "network", "0", "port")
 	// +kubebuilder:validation:Optional
 	ResourceID *string `json:"resourceId,omitempty" tf:"resource_id,omitempty"`
 

--- a/apis/mrs/v1beta1/zz_cluster_types.go
+++ b/apis/mrs/v1beta1/zz_cluster_types.go
@@ -293,7 +293,7 @@ type ClusterParameters struct {
 	// Specifies the ID of the VPC Subnet which bound to the MRS cluster.
 	// Changing this will create a new MRS cluster resource.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/mrs/v1beta1/zz_generated.resolvers.go
+++ b/apis/mrs/v1beta1/zz_generated.resolvers.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	v1beta1 "github.com/FrangipaneTeam/provider-flexibleengine/apis/eip/v1beta1"
 	v1beta11 "github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1"
-	common "github.com/FrangipaneTeam/provider-flexibleengine/config/common"
+	tools "github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,7 +40,7 @@ func (mg *Cluster) ResolveReferences(ctx context.Context, c client.Reader) error
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.SubnetID),
-		Extract:      common.IDExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "id"),
 		Reference:    mg.Spec.ForProvider.SubnetIDRef,
 		Selector:     mg.Spec.ForProvider.SubnetIDSelector,
 		To: reference.To{

--- a/apis/mrsd/v1beta1/zz_cluster_types.go
+++ b/apis/mrsd/v1beta1/zz_cluster_types.go
@@ -271,7 +271,7 @@ type ClusterParameters struct {
 	// Specifies the ID of the VPC Subnet which bound to the MRS cluster.
 	// Changing this will create a new MRS cluster resource.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/mrsd/v1beta1/zz_generated.resolvers.go
+++ b/apis/mrsd/v1beta1/zz_generated.resolvers.go
@@ -8,7 +8,7 @@ package v1beta1
 import (
 	"context"
 	v1beta1 "github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1"
-	common "github.com/FrangipaneTeam/provider-flexibleengine/config/common"
+	tools "github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,7 +23,7 @@ func (mg *Cluster) ResolveReferences(ctx context.Context, c client.Reader) error
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.SubnetID),
-		Extract:      common.IDExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "id"),
 		Reference:    mg.Spec.ForProvider.SubnetIDRef,
 		Selector:     mg.Spec.ForProvider.SubnetIDSelector,
 		To: reference.To{
@@ -81,7 +81,7 @@ func (mg *HybridCluster) ResolveReferences(ctx context.Context, c client.Reader)
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.SubnetID),
-		Extract:      common.IDExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "id"),
 		Reference:    mg.Spec.ForProvider.SubnetIDRef,
 		Selector:     mg.Spec.ForProvider.SubnetIDSelector,
 		To: reference.To{

--- a/apis/mrsd/v1beta1/zz_hybridcluster_types.go
+++ b/apis/mrsd/v1beta1/zz_hybridcluster_types.go
@@ -247,7 +247,7 @@ type HybridClusterParameters struct {
 
 	// Specifies the ID of the VPC Subnet.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/nat/v1beta1/zz_gateway_types.go
+++ b/apis/nat/v1beta1/zz_gateway_types.go
@@ -54,7 +54,7 @@ type GatewayParameters struct {
 	// Specifies the ID of the VPC Subnet of the downstream interface
 	// (the next hop of the DVR) of the NAT gateway. Changing this creates a new nat gateway.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/nat/v1beta1/zz_generated.resolvers.go
+++ b/apis/nat/v1beta1/zz_generated.resolvers.go
@@ -10,7 +10,7 @@ import (
 	v1beta1 "github.com/FrangipaneTeam/provider-flexibleengine/apis/eip/v1beta1"
 	v1beta12 "github.com/FrangipaneTeam/provider-flexibleengine/apis/iam/v1beta1"
 	v1beta11 "github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1"
-	common "github.com/FrangipaneTeam/provider-flexibleengine/config/common"
+	tools "github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -83,7 +83,7 @@ func (mg *Gateway) ResolveReferences(ctx context.Context, c client.Reader) error
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.SubnetID),
-		Extract:      common.IDExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "id"),
 		Reference:    mg.Spec.ForProvider.SubnetIDRef,
 		Selector:     mg.Spec.ForProvider.SubnetIDSelector,
 		To: reference.To{
@@ -173,7 +173,7 @@ func (mg *SnatRule) ResolveReferences(ctx context.Context, c client.Reader) erro
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.NetworkID),
-		Extract:      common.IDExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "id"),
 		Reference:    mg.Spec.ForProvider.NetworkIDRef,
 		Selector:     mg.Spec.ForProvider.NetworkIDSelector,
 		To: reference.To{
@@ -189,7 +189,7 @@ func (mg *SnatRule) ResolveReferences(ctx context.Context, c client.Reader) erro
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.SubnetID),
-		Extract:      common.IDExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "id"),
 		Reference:    mg.Spec.ForProvider.SubnetIDRef,
 		Selector:     mg.Spec.ForProvider.SubnetIDSelector,
 		To: reference.To{

--- a/apis/nat/v1beta1/zz_snatrule_types.go
+++ b/apis/nat/v1beta1/zz_snatrule_types.go
@@ -62,7 +62,7 @@ type SnatRuleParameters struct {
 
 	// The resource ID in UUID format.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +kubebuilder:validation:Optional
 	NetworkID *string `json:"networkId,omitempty" tf:"network_id,omitempty"`
 
@@ -90,7 +90,7 @@ type SnatRuleParameters struct {
 	// ID of the VPC Subnet this snat rule connects to.
 	// This parameter and cidr are alternative. Changing this creates a new snat rule.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/oss/v1beta1/zz_generated.resolvers.go
+++ b/apis/oss/v1beta1/zz_generated.resolvers.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	v1beta11 "github.com/FrangipaneTeam/provider-flexibleengine/apis/iam/v1beta1"
 	v1beta1 "github.com/FrangipaneTeam/provider-flexibleengine/apis/kms/v1beta1"
-	common "github.com/FrangipaneTeam/provider-flexibleengine/config/common"
+	tools "github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -76,7 +76,7 @@ func (mg *OBSBucketReplication) ResolveReferences(ctx context.Context, c client.
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Agency),
-		Extract:      common.NameExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(false, "name"),
 		Reference:    mg.Spec.ForProvider.AgencyRef,
 		Selector:     mg.Spec.ForProvider.AgencySelector,
 		To: reference.To{

--- a/apis/oss/v1beta1/zz_obsbucketreplication_types.go
+++ b/apis/oss/v1beta1/zz_obsbucketreplication_types.go
@@ -27,7 +27,7 @@ type OBSBucketReplicationParameters struct {
 
 	// Specifies the IAM agency applied to the cross-region replication function.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/iam/v1beta1.Agency
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.NameExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(false, "name")
 	// +kubebuilder:validation:Optional
 	Agency *string `json:"agency,omitempty" tf:"agency,omitempty"`
 

--- a/apis/rds/v1beta1/zz_generated.resolvers.go
+++ b/apis/rds/v1beta1/zz_generated.resolvers.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	v1beta11 "github.com/FrangipaneTeam/provider-flexibleengine/apis/kms/v1beta1"
 	v1beta1 "github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1"
-	common "github.com/FrangipaneTeam/provider-flexibleengine/config/common"
+	tools "github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -118,7 +118,7 @@ func (mg *Instance) ResolveReferences(ctx context.Context, c client.Reader) erro
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.SubnetID),
-		Extract:      common.IDExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "id"),
 		Reference:    mg.Spec.ForProvider.SubnetIDRef,
 		Selector:     mg.Spec.ForProvider.SubnetIDSelector,
 		To: reference.To{

--- a/apis/rds/v1beta1/zz_instance_types.go
+++ b/apis/rds/v1beta1/zz_instance_types.go
@@ -180,7 +180,7 @@ type InstanceParameters struct {
 	// Specifies the ID of the VPC Subnet.
 	// Changing this parameter will create a new resource.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/sfs/v1beta1/zz_generated.resolvers.go
+++ b/apis/sfs/v1beta1/zz_generated.resolvers.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	v1beta1 "github.com/FrangipaneTeam/provider-flexibleengine/apis/kms/v1beta1"
 	v1beta11 "github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1"
-	common "github.com/FrangipaneTeam/provider-flexibleengine/config/common"
+	tools "github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -82,7 +82,7 @@ func (mg *Turbo) ResolveReferences(ctx context.Context, c client.Reader) error {
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.SubnetID),
-		Extract:      common.IDExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "id"),
 		Reference:    mg.Spec.ForProvider.SubnetIDRef,
 		Selector:     mg.Spec.ForProvider.SubnetIDSelector,
 		To: reference.To{

--- a/apis/sfs/v1beta1/zz_turbo_types.go
+++ b/apis/sfs/v1beta1/zz_turbo_types.go
@@ -90,7 +90,7 @@ type TurboParameters struct {
 
 	// Specifies the ID of the VPC Subnet. Changing this will create a new resource.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/vpc/v1beta1/zz_generated.resolvers.go
+++ b/apis/vpc/v1beta1/zz_generated.resolvers.go
@@ -8,7 +8,7 @@ package v1beta1
 import (
 	"context"
 	v1beta1 "github.com/FrangipaneTeam/provider-flexibleengine/apis/iam/v1beta1"
-	common "github.com/FrangipaneTeam/provider-flexibleengine/config/common"
+	tools "github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -109,7 +109,7 @@ func (mg *Port) ResolveReferences(ctx context.Context, c client.Reader) error {
 	}
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.NetworkID),
-		Extract:      common.IDExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "id"),
 		Reference:    mg.Spec.ForProvider.NetworkIDRef,
 		Selector:     mg.Spec.ForProvider.NetworkIDSelector,
 		To: reference.To{
@@ -194,7 +194,7 @@ func (mg *RouteTable) ResolveReferences(ctx context.Context, c client.Reader) er
 
 	mrsp, err = r.ResolveMultiple(ctx, reference.MultiResolutionRequest{
 		CurrentValues: reference.FromPtrValues(mg.Spec.ForProvider.Subnets),
-		Extract:       common.IDExtractor(),
+		Extract:       tools.ExtractorParamPathfunc(true, "id"),
 		References:    mg.Spec.ForProvider.SubnetsRefs,
 		Selector:      mg.Spec.ForProvider.SubnetSelector,
 		To: reference.To{
@@ -320,7 +320,7 @@ func (mg *VIP) ResolveReferences(ctx context.Context, c client.Reader) error {
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.NetworkID),
-		Extract:      common.IDExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "id"),
 		Reference:    mg.Spec.ForProvider.NetworkIDRef,
 		Selector:     mg.Spec.ForProvider.NetworkIDSelector,
 		To: reference.To{

--- a/apis/vpc/v1beta1/zz_port_types.go
+++ b/apis/vpc/v1beta1/zz_port_types.go
@@ -107,7 +107,7 @@ type PortParameters struct {
 	// The ID of the VPC Subnet to attach the port to. Changing
 	// this creates a new port.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +kubebuilder:validation:Optional
 	NetworkID *string `json:"networkId,omitempty" tf:"network_id,omitempty"`
 

--- a/apis/vpc/v1beta1/zz_routetable_types.go
+++ b/apis/vpc/v1beta1/zz_routetable_types.go
@@ -47,7 +47,7 @@ type RouteTableParameters struct {
 
 	// Specifies an array of one or more subnets associating with the route table.
 	// +crossplane:generate:reference:type=VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +crossplane:generate:reference:selectorFieldName=SubnetSelector
 	// +kubebuilder:validation:Optional
 	Subnets []*string `json:"subnets,omitempty" tf:"subnets,omitempty"`

--- a/apis/vpc/v1beta1/zz_vip_types.go
+++ b/apis/vpc/v1beta1/zz_vip_types.go
@@ -50,7 +50,7 @@ type VIPParameters struct {
 	// Specifies the ID of the VPC Subnet to which the VIP belongs.
 	// Changing this will create a new VIP resource.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +kubebuilder:validation:Optional
 	NetworkID *string `json:"networkId,omitempty" tf:"network_id,omitempty"`
 

--- a/apis/vpcep/v1beta1/zz_endpoint_types.go
+++ b/apis/vpcep/v1beta1/zz_endpoint_types.go
@@ -55,7 +55,7 @@ type EndpointParameters struct {
 	// Specifies the network ID of the subnet in the VPC specified by vpc_id.
 	// Changing this creates a new VPC endpoint.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +kubebuilder:validation:Optional
 	NetworkID *string `json:"networkId,omitempty" tf:"network_id,omitempty"`
 

--- a/apis/vpcep/v1beta1/zz_generated.resolvers.go
+++ b/apis/vpcep/v1beta1/zz_generated.resolvers.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	v1beta11 "github.com/FrangipaneTeam/provider-flexibleengine/apis/ecs/v1beta1"
 	v1beta1 "github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1"
-	common "github.com/FrangipaneTeam/provider-flexibleengine/config/common"
+	tools "github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -67,7 +67,7 @@ func (mg *Endpoint) ResolveReferences(ctx context.Context, c client.Reader) erro
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.NetworkID),
-		Extract:      common.IDExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "id"),
 		Reference:    mg.Spec.ForProvider.NetworkIDRef,
 		Selector:     mg.Spec.ForProvider.NetworkIDSelector,
 		To: reference.To{
@@ -125,7 +125,7 @@ func (mg *VPCEPService) ResolveReferences(ctx context.Context, c client.Reader) 
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.PortID),
-		Extract:      common.NetworkPortIDExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "network", "0", "port"),
 		Reference:    mg.Spec.ForProvider.PortIDRef,
 		Selector:     mg.Spec.ForProvider.PortIDSelector,
 		To: reference.To{

--- a/apis/vpcep/v1beta1/zz_vpcepservice_types.go
+++ b/apis/vpcep/v1beta1/zz_vpcepservice_types.go
@@ -86,7 +86,7 @@ type VPCEPServiceParameters struct {
 
 	// Specifies the ID for identifying the backend resource of the VPC endpoint service.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/ecs/v1beta1.Instance
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.NetworkPortIDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "network", "0", "port")
 	// +kubebuilder:validation:Optional
 	PortID *string `json:"portId,omitempty" tf:"port_id,omitempty"`
 

--- a/apis/waf/v1beta1/zz_dedicatedinstance_types.go
+++ b/apis/waf/v1beta1/zz_dedicatedinstance_types.go
@@ -97,7 +97,7 @@ type DedicatedInstanceParameters struct {
 	// The ID of the VPC Subnet.
 	// Changing this will create a new instance.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
-	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/config/common.IDExtractor()
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/waf/v1beta1/zz_generated.resolvers.go
+++ b/apis/waf/v1beta1/zz_generated.resolvers.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	v1beta1 "github.com/FrangipaneTeam/provider-flexibleengine/apis/ecs/v1beta1"
 	v1beta11 "github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1"
-	common "github.com/FrangipaneTeam/provider-flexibleengine/config/common"
+	tools "github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -99,7 +99,7 @@ func (mg *DedicatedInstance) ResolveReferences(ctx context.Context, c client.Rea
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.SubnetID),
-		Extract:      common.IDExtractor(),
+		Extract:      tools.ExtractorParamPathfunc(true, "id"),
 		Reference:    mg.Spec.ForProvider.SubnetIDRef,
 		Selector:     mg.Spec.ForProvider.SubnetIDSelector,
 		To: reference.To{

--- a/config/as/config.go
+++ b/config/as/config.go
@@ -4,7 +4,6 @@ package as
 import (
 	"github.com/upbound/upjet/pkg/config"
 
-	"github.com/FrangipaneTeam/provider-flexibleengine/config/common"
 	"github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 )
 
@@ -50,7 +49,7 @@ func Configure(p *config.Provider) {
 		r.References["networks.id"] = config.Reference{
 			// Require Network ID of VPC Subnet
 			TerraformName: "flexibleengine_vpc_subnet_v1",
-			Extractor:     common.PathIDExtractor,
+			Extractor:     tools.GenerateExtractor(true, "id"),
 		}
 	})
 

--- a/config/bms/config.go
+++ b/config/bms/config.go
@@ -4,7 +4,6 @@ package bms
 import (
 	"github.com/upbound/upjet/pkg/config"
 
-	"github.com/FrangipaneTeam/provider-flexibleengine/config/common"
 	"github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 )
 
@@ -28,13 +27,13 @@ func Configure(p *config.Provider) {
 		// security_groups
 		r.References["security_groups"] = config.Reference{
 			TerraformName: "flexibleengine_networking_secgroup_v2",
-			Extractor:     common.PathNameExtractor,
+			Extractor:     tools.GenerateExtractor(false, "name"),
 		}
 
 		r.References["network.uuid"] = config.Reference{
 			// Require Network ID of VPC Subnet
 			TerraformName: "flexibleengine_vpc_subnet_v1",
-			Extractor:     common.PathIDExtractor,
+			Extractor:     tools.GenerateExtractor(true, "id"),
 		}
 
 		r.References["network.port"] = config.Reference{

--- a/config/cce/config.go
+++ b/config/cce/config.go
@@ -4,7 +4,6 @@ package cce
 import (
 	"github.com/upbound/upjet/pkg/config"
 
-	"github.com/FrangipaneTeam/provider-flexibleengine/config/common"
 	"github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 )
 
@@ -30,7 +29,7 @@ func Configure(p *config.Provider) {
 		}
 		r.References["eip"] = config.Reference{
 			Type:      tools.GenerateType("eip", "EIP"),
-			Extractor: common.PathAddressExtractor,
+			Extractor: tools.GenerateExtractor(true, "address"),
 		}
 	})
 

--- a/config/common/common.go
+++ b/config/common/common.go
@@ -16,28 +16,24 @@ var (
 	// SelfPackagePath is the golang path for this package.
 	SelfPackagePath = fmt.Sprintf("%s/config/common", tools.ModulePath)
 
-	// PathARNExtractor is the golang path to ARNExtractor function
-	// in this package.
-	PathARNExtractor = SelfPackagePath + ".ARNExtractor()"
-
 	// PathTerraformIDExtractor is the golang path to TerraformID extractor
 	// function in this package.
-	PathTerraformIDExtractor = SelfPackagePath + ".TerraformID()"
+	PathTerraformIDExtractor = SelfPackagePath + ".TerraformID()" // Not used
 
 	// PathRegionExtractor is the golang path to RegionExtractor function
-	PathRegionExtractor = SelfPackagePath + ".RegionExtractor()"
+	PathRegionExtractor = SelfPackagePath + ".RegionExtractor()" // Not used
 
 	// PathImageNameExtractor is the golang path to ImageNameExtractor function
-	PathImageNameExtractor = SelfPackagePath + ".ImageNameExtractor()"
+	PathImageNameExtractor = SelfPackagePath + ".ImageNameExtractor()" // Not used
 
 	// PathDBNameExtractor is the golang path to DBNameExtractor function
-	PathDBNameExtractor = SelfPackagePath + ".DBNameExtractor()"
+	PathDBNameExtractor = SelfPackagePath + ".DBNameExtractor()" // Not used
 
 	// PathNameExtractor is the golang path to NameExtractor function
 	PathNameExtractor = SelfPackagePath + ".NameExtractor()"
 
 	// PathBucketNameExtractor is the golang path to BucketNameExtractor function
-	PathBucketNameExtractor = SelfPackagePath + ".BucketNameExtractor()"
+	PathBucketNameExtractor = SelfPackagePath + ".BucketNameExtractor()" // Not used
 
 	// PathAddressExtractor is the golang path to AddressExtractor function
 	PathAddressExtractor = SelfPackagePath + ".AddressExtractor()"
@@ -48,6 +44,15 @@ var (
 	// PathNetworkPortIDExtractor is the golang path to NetworkPortIDExtractor function
 	PathNetworkPortIDExtractor = SelfPackagePath + ".NetworkPortIDExtractor()"
 )
+
+/*
+
+	> DEPRECATED
+	> common PathExtractor functions are deprecated and will be removed in the future.
+	> Please use the functions in the tools package instead.
+	> tools.GenerateExtractor(true, "network", "0", "port")
+
+*/
 
 // NetworkPortIDExtractor extracts network port ID from "status.atProvider.network[0].port"
 func NetworkPortIDExtractor() reference.ExtractValueFn {

--- a/config/dedicatedelb/config.go
+++ b/config/dedicatedelb/config.go
@@ -4,7 +4,6 @@ package dedicatedelb
 import (
 	"github.com/upbound/upjet/pkg/config"
 
-	"github.com/FrangipaneTeam/provider-flexibleengine/config/common"
 	"github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 )
 
@@ -41,7 +40,7 @@ func Configure(p *config.Provider) {
 		}
 		r.References["ipv6_network_id"] = config.Reference{
 			Type:      tools.GenerateType("vpc", "VPCSubnet"),
-			Extractor: common.PathIDExtractor,
+			Extractor: tools.GenerateExtractor(true, "id"),
 		}
 		r.References["ipv4_eip_id"] = config.Reference{
 			Type: tools.GenerateType("eip", "EIP"),

--- a/config/ecs/config.go
+++ b/config/ecs/config.go
@@ -25,7 +25,7 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("flexibleengine_compute_instance_v2", func(r *config.Resource) {
 		r.References["network.uuid"] = config.Reference{
 			Type:      tools.GenerateType("vpc", "VPCSubnet"),
-			Extractor: common.PathIDExtractor,
+			Extractor: tools.GenerateExtractor(true, "id"),
 		}
 
 		r.References["network.port"] = config.Reference{

--- a/config/eip/config.go
+++ b/config/eip/config.go
@@ -4,7 +4,7 @@ package eip
 import (
 	"github.com/upbound/upjet/pkg/config"
 
-	"github.com/FrangipaneTeam/provider-flexibleengine/config/common"
+	"github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.
@@ -14,7 +14,7 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("flexibleengine_vpc_eip_associate", func(r *config.Resource) {
 		r.References["public_ip"] = config.Reference{
 			Type:      "EIP",
-			Extractor: common.PathAddressExtractor,
+			Extractor: tools.GenerateExtractor(true, "address"),
 		}
 		r.LateInitializer = config.LateInitializer{
 			IgnoredFields: []string{"fixed_ip", "port_id", "network_id"},

--- a/config/lts/config.go
+++ b/config/lts/config.go
@@ -4,7 +4,6 @@ package lts
 import (
 	"github.com/upbound/upjet/pkg/config"
 
-	"github.com/FrangipaneTeam/provider-flexibleengine/config/common"
 	"github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 )
 
@@ -28,7 +27,7 @@ func Configure(p *config.Provider) {
 
 		r.References["resource_id"] = config.Reference{
 			Type:      tools.GenerateType("ecs", "Instance"),
-			Extractor: common.PathNetworkPortIDExtractor,
+			Extractor: tools.GenerateExtractor(true, "network", "0", "port"),
 		}
 
 		r.References["log_group_id"] = config.Reference{

--- a/config/oss/config.go
+++ b/config/oss/config.go
@@ -4,7 +4,6 @@ package oss
 import (
 	"github.com/upbound/upjet/pkg/config"
 
-	"github.com/FrangipaneTeam/provider-flexibleengine/config/common"
 	"github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 )
 
@@ -56,7 +55,7 @@ func Configure(p *config.Provider) {
 		}
 		r.References["agency"] = config.Reference{
 			Type:      tools.GenerateType("iam", "Agency"),
-			Extractor: common.PathNameExtractor,
+			Extractor: tools.GenerateExtractor(false, "name"),
 		}
 	})
 

--- a/config/overrides.go
+++ b/config/overrides.go
@@ -3,7 +3,6 @@ package config
 import (
 	"github.com/upbound/upjet/pkg/config"
 
-	"github.com/FrangipaneTeam/provider-flexibleengine/config/common"
 	"github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 )
 
@@ -23,26 +22,11 @@ func KnownReferencers() config.ResourceOption { //nolint:gocyclo
 				r.References[k] = config.Reference{
 					Type: tools.GenerateType("vpc", "VPC"),
 				}
-				// subnet_id is a reference to a Subnet resource
-			case "subnet_id":
+			// subnet_id and network_id is a reference to a Subnet resource
+			case "subnet_id", "network_id":
 				r.References[k] = config.Reference{
 					Type:      tools.GenerateType("vpc", "VPCSubnet"),
-					Extractor: common.PathIDExtractor,
-				}
-				// if _, ok := r.TerraformResource.Schema["network_id"]; ok {
-				// 	r.References[k] = config.Reference{
-				// 		Type: tools.GenerateType("vpc", "NetworkingSubnet"),
-				// 	}
-				// } else {
-				// 	r.References[k] = config.Reference{
-				// 		Type: tools.GenerateType("vpc", "VPCSubnet"),
-				// 	}
-				// }
-				// network_id is a reference to a Network resource
-			case "network_id":
-				r.References[k] = config.Reference{
-					Type:      tools.GenerateType("vpc", "VPCSubnet"),
-					Extractor: common.PathIDExtractor,
+					Extractor: tools.GenerateExtractor(true, "id"),
 				}
 				// security_group_id is a reference to a SecurityGroup resource
 			case "security_group_id":
@@ -72,7 +56,7 @@ func KnownReferencers() config.ResourceOption { //nolint:gocyclo
 			case "image_name":
 				r.References[k] = config.Reference{
 					TerraformName: "flexibleengine_images_image_v2",
-					Extractor:     common.PathImageNameExtractor,
+					Extractor:     tools.GenerateExtractor(false, "image_name"),
 				}
 			case "image_id":
 				r.References[k] = config.Reference{

--- a/config/vpc/config.go
+++ b/config/vpc/config.go
@@ -4,7 +4,7 @@ package vpc
 import (
 	"github.com/upbound/upjet/pkg/config"
 
-	"github.com/FrangipaneTeam/provider-flexibleengine/config/common"
+	"github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.
@@ -17,7 +17,7 @@ func Configure(p *config.Provider) {
 		// Subnets is a list of Subnet IDs
 		r.References["subnets"] = config.Reference{
 			Type:              "VPCSubnet",
-			Extractor:         common.PathIDExtractor,
+			Extractor:         tools.GenerateExtractor(true, "id"),
 			SelectorFieldName: "SubnetSelector", // Selector is only one reference
 		}
 

--- a/config/vpcep/config.go
+++ b/config/vpcep/config.go
@@ -4,7 +4,6 @@ package vpcep
 import (
 	"github.com/upbound/upjet/pkg/config"
 
-	"github.com/FrangipaneTeam/provider-flexibleengine/config/common"
 	"github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 )
 
@@ -16,7 +15,7 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("flexibleengine_vpcep_service", func(r *config.Resource) {
 		r.References["port_id"] = config.Reference{
 			Type:      tools.GenerateType("ecs", "Instance"),
-			Extractor: common.PathNetworkPortIDExtractor,
+			Extractor: tools.GenerateExtractor(true, "network", "0", "port"),
 		}
 	})
 

--- a/examples/oss/obsbucketreplication.yaml
+++ b/examples/oss/obsbucketreplication.yaml
@@ -44,7 +44,7 @@ metadata:
   name: default1
 spec:
   region: eu-west-1
-  domainName: OCB000OOOO
+  domainName: OCB0002447
   credentials:
     source: Secret
     secretRef:

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -4,6 +4,10 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
+	xpref "github.com/crossplane/crossplane-runtime/pkg/reference"
+	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 )
 
 // VersionV1Beta1 is used to signify that the resource has been tested and external name configured
@@ -25,6 +29,34 @@ const (
 // "github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPC"
 func GenerateType(module, _type string) string {
 	return fmt.Sprintf("%s/apis/%s/%s.%s", ModulePath, module, Version, _type)
+}
+
+// GenerateExtractor generates the extractor path.
+// Extracts the value of `sourceAttrs`
+// from `spec.forProvider` allowing nested parameters.
+// If `isStatus` is set, then referenced param
+// is retrieved from the status, if not, it's extracted
+// from the spec.
+// An example argument to GenerateExtractor is
+// `key`, if `spec.forProvider.key` is to be extracted
+// from the referred resource.
+// Other examples are `"network", "0", "id"` is converted to
+// `spec.forProvider.network[0].id`
+func GenerateExtractor(isStatus bool, sourceAttrs ...string) string {
+
+	var sourceAttr string
+
+	if len(sourceAttrs) > 1 {
+		listOfSourceAttr := []string{}
+		for _, sourceAttr := range sourceAttrs {
+			listOfSourceAttr = append(listOfSourceAttr, fmt.Sprintf("\"%s\"", sourceAttr))
+		}
+		sourceAttr = strings.Join(listOfSourceAttr, ", ")
+	} else {
+		sourceAttr = fmt.Sprintf("\"%s\"", sourceAttrs[0])
+	}
+	// Resultat is ExtractorParamPathfunc(true, "network", "0", "id")
+	return fmt.Sprintf("%s/pkg/tools.ExtractorParamPathfunc(%t, %s)", ModulePath, isStatus, sourceAttr)
 }
 
 // RemoveVersion removes the version from the resource name
@@ -52,4 +84,42 @@ func RemovePrefix(name string) string {
 // "subnet"
 func RemoveGroup(name []string) string {
 	return strings.Join(name[1:], "_")
+}
+
+// ExtractorParamPathfunc extracts the value of `sourceAttrs`
+func ExtractorParamPathfunc(isStatus bool, sourceAttrs ...string) xpref.ExtractValueFn {
+	return func(mg xpresource.Managed) string {
+
+		var (
+			err error
+			r   string
+		)
+
+		paved, err := fieldpath.PaveObject(mg)
+		if err != nil {
+			return ""
+		}
+
+		sourceAttr := strings.Join(sourceAttrs, ".")
+
+		// if sourceAttr match this regex network.[0-9].id transform to network[0].id
+		rg := regexp.MustCompile(`(.*)\.([0-9])\.(.*)`)
+		if rg.MatchString(sourceAttr) {
+			sourceAttr = rg.ReplaceAllString(sourceAttr, "$1[$2].$3")
+		}
+
+		if isStatus {
+			r, err = paved.GetString(fmt.Sprintf("status.atProvider.%s", sourceAttr))
+			if err != nil {
+				return ""
+			}
+		} else {
+			r, err = paved.GetString(fmt.Sprintf("spec.forProvider.%s", sourceAttr))
+			if err != nil {
+				return ""
+			}
+		}
+		return r
+
+	}
 }


### PR DESCRIPTION
### Description of your changes

Actually Extractor func is define in common package and declare one new func for each case. 

I'm write in tools package a generic func for each case. 

Example : 

### Before 

```
// PathNetworkPortIDExtractor is the golang path to NetworkPortIDExtractor function
PathNetworkPortIDExtractor = SelfPackagePath + ".NetworkPortIDExtractor()"

// NetworkPortIDExtractor extracts network port ID from "status.atProvider.network[0].port"
func NetworkPortIDExtractor() reference.ExtractValueFn {
	return func(mg xpresource.Managed) string {
		paved, err := fieldpath.PaveObject(mg)
		if err != nil {
			// TODO should we log this error?
			return ""
		}
		r, err := paved.GetString("status.atProvider.network[0].port")
		if err != nil {
			// TODO should we log this error?
			return ""
		}
		return r
	}
}
```
### After 
```
tools.GenerateExtractor(true, "network", "0", "port")
```

## How to func working ? 
```
// GenerateExtractor generates the extractor path.
// Extracts the value of `sourceAttrs`
// from `spec.forProvider` allowing nested parameters.
// If `isStatus` is set, then referenced param
// is retrieved from the status, if not, it's extracted
// from the spec.
// An example argument to GenerateExtractor is
// `key`, if `spec.forProvider.key` is to be extracted
// from the referred resource.
// Other examples are `"network", "0", "id"` is converted to
// `spec.forProvider.network[0].id`
func GenerateExtractor(isStatus bool, sourceAttrs ...string)
```

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I tested on many resources

```
NAME                                                            READY   SYNCED   EXTERNAL-NAME                          AGE
servergroup.ecs.flexibleengine.upbound.io/example-servergroup   True    True     REDACTED   3h51m

NAME                                                      READY   SYNCED   EXTERNAL-NAME                          AGE
instance.ecs.flexibleengine.upbound.io/example-instance   True    True     REDACTED   3h51m

NAME                                                    READY   SYNCED   EXTERNAL-NAME     AGE
keypair.ecs.flexibleengine.upbound.io/example-keypair   True    True     REDACTED   3h51m

NAME                                                  READY   SYNCED   EXTERNAL-NAME                      AGE
agency.iam.flexibleengine.upbound.io/example-agency   True    True     REDACTED   12m

NAME                                                                    READY   SYNCED   EXTERNAL-NAME                                 AGE
obsbucket.oss.flexibleengine.upbound.io/example-obsbucket               True    True     REDACTED                  12m
obsbucket.oss.flexibleengine.upbound.io/example-destination-obsbucket   True    True     REDACTED   12m

NAME                                                                              READY   SYNCED   EXTERNAL-NAME                  AGE
obsbucketreplication.oss.flexibleengine.upbound.io/example-obsbucketreplication   True    True     myREDACTED   12m

NAME                                            READY   SYNCED   EXTERNAL-NAME                          AGE
vpc.vpc.flexibleengine.upbound.io/example-vpc   True    True     REDACTED   3h51m

NAME                                                     READY   SYNCED   EXTERNAL-NAME                          AGE
vpcsubnet.vpc.flexibleengine.upbound.io/example-subnet   True    True     REDACTED   3h51m

NAME                                                                 READY   SYNCED   EXTERNAL-NAME                          AGE
vpcepservice.vpcep.flexibleengine.upbound.io/example-vpcep-service   True    True     REDACTED   172m
```

## Note

I'm not removing all common features as many pull requests are in review/draft.
I remove it later