### PR TITLE
ci: issues and PR triage with labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,44 @@
+version: v1
+
+labels:
+  - label: "feature"
+    sync: true
+    matcher:
+      title: "^feat.*"
+      commits: "^feat.*"
+
+  - label: "bugfix"
+    sync: true
+    matcher:
+      title: "^fix.*"
+      commits: "^fix.*"
+
+  - label: "documentation"
+    sync: true
+    matcher:
+      title: "^docs.*"
+      commits: "^docs.*"
+
+  - label: "ci"
+    sync: true
+    matcher:
+      title: "^ci.*"
+      commits: "^ci.*"
+
+  - label: "refactor"
+    sync: true
+    matcher:
+      title: "^refactor.*"
+      commits: "^refactor.*"
+
+  - label: "chore"
+    sync: true
+    matcher:
+      title: "^chore.*"
+      commits: "^chore.*"
+
+  - label: "dependencies"
+    sync: true
+    matcher:
+      files:
+        any: [ "go.mod" ]

--- a/.github/workflows/issue_triage.yml
+++ b/.github/workflows/issue_triage.yml
@@ -1,4 +1,4 @@
-name: Issue Labeler
+name: Issue Triage
 
 on:
   issues:

--- a/.github/workflows/pr_triage.yml
+++ b/.github/workflows/pr_triage.yml
@@ -1,14 +1,23 @@
-name: Pull Request Treatment
+name: PR Triage
 
 on: 
-  pull_request_target:
+  pull_request:
     types: [ opened, edited, reopened, synchronize ]
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   labeler:
     runs-on: ubuntu-latest
-    name: Label the PR size
+    name: Labeler
     steps:
+      - uses: fuxingloh/multi-labeler@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          config-path: .github/labeler.yml
+
       - uses: codelytv/pr-size-labeler@v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -24,7 +33,7 @@ jobs:
           fail_if_xl: 'false'
 
   validate-title:
-    name: Validate PR title
+    name: Validate title
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5


### PR DESCRIPTION
- Rename jobs
- Reduce permission on PR Triage
- Add labeler job to PR with some keywords