### PR TITLE
feat(dli): add examples

### DIFF
--- a/apis/dli/v1beta1/zz_flinksqljob_types.go
+++ b/apis/dli/v1beta1/zz_flinksqljob_types.go
@@ -75,8 +75,17 @@ type FlinksqlJobParameters struct {
 	// Specifies OBS path. OBS path where users are authorized to save the
 	// snapshot. This parameter is valid only when checkpoint_enabled is set to true. OBS path where users are authorized
 	// to save the snapshot. This parameter is valid only when log_enabled is set to true.
+	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/oss/v1beta1.OBSBucket
 	// +kubebuilder:validation:Optional
 	ObsBucket *string `json:"obsBucket,omitempty" tf:"obs_bucket,omitempty"`
+
+	// Reference to a OBSBucket in oss to populate obsBucket.
+	// +kubebuilder:validation:Optional
+	ObsBucketRef *v1.Reference `json:"obsBucketRef,omitempty" tf:"-"`
+
+	// Selector for a OBSBucket in oss to populate obsBucket.
+	// +kubebuilder:validation:Optional
+	ObsBucketSelector *v1.Selector `json:"obsBucketSelector,omitempty" tf:"-"`
 
 	// Specifies number of parallel for a job. The default value is 1.
 	// +kubebuilder:validation:Optional
@@ -104,8 +113,8 @@ type FlinksqlJobParameters struct {
 	// Specifies maximum number of retry times upon exceptions. The unit is
 	// times/hour. Value range: -1 or greater than 0. The default value is -1, indicating that the number of times is
 	// unlimited.
-	// +kubebuilder:validation:Optional
-	ResumeMaxNum *float64 `json:"resumeMaxNum,omitempty" tf:"resume_max_num,omitempty"`
+	// +kubebuilder:validation:Required
+	ResumeMaxNum *float64 `json:"resumeMaxNum" tf:"resume_max_num,omitempty"`
 
 	// Specifies job running mode. The options are as follows:
 	// +kubebuilder:validation:Optional

--- a/apis/dli/v1beta1/zz_generated.deepcopy.go
+++ b/apis/dli/v1beta1/zz_generated.deepcopy.go
@@ -590,6 +590,16 @@ func (in *FlinksqlJobParameters) DeepCopyInto(out *FlinksqlJobParameters) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ObsBucketRef != nil {
+		in, out := &in.ObsBucketRef, &out.ObsBucketRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ObsBucketSelector != nil {
+		in, out := &in.ObsBucketSelector, &out.ObsBucketSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ParallelNumber != nil {
 		in, out := &in.ParallelNumber, &out.ParallelNumber
 		*out = new(float64)

--- a/apis/dli/v1beta1/zz_generated.resolvers.go
+++ b/apis/dli/v1beta1/zz_generated.resolvers.go
@@ -7,7 +7,8 @@ package v1beta1
 
 import (
 	"context"
-	v1beta1 "github.com/FrangipaneTeam/provider-flexibleengine/apis/smn/v1beta1"
+	v1beta1 "github.com/FrangipaneTeam/provider-flexibleengine/apis/oss/v1beta1"
+	v1beta11 "github.com/FrangipaneTeam/provider-flexibleengine/apis/smn/v1beta1"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -21,13 +22,29 @@ func (mg *FlinksqlJob) ResolveReferences(ctx context.Context, c client.Reader) e
 	var err error
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.ObsBucket),
+		Extract:      reference.ExternalName(),
+		Reference:    mg.Spec.ForProvider.ObsBucketRef,
+		Selector:     mg.Spec.ForProvider.ObsBucketSelector,
+		To: reference.To{
+			List:    &v1beta1.OBSBucketList{},
+			Managed: &v1beta1.OBSBucket{},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.ForProvider.ObsBucket")
+	}
+	mg.Spec.ForProvider.ObsBucket = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.ForProvider.ObsBucketRef = rsp.ResolvedReference
+
+	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.SmnTopic),
 		Extract:      reference.ExternalName(),
 		Reference:    mg.Spec.ForProvider.SmnTopicRef,
 		Selector:     mg.Spec.ForProvider.SmnTopicSelector,
 		To: reference.To{
-			List:    &v1beta1.TopicList{},
-			Managed: &v1beta1.Topic{},
+			List:    &v1beta11.TopicList{},
+			Managed: &v1beta11.Topic{},
 		},
 	})
 	if err != nil {

--- a/apis/dli/v1beta1/zz_generated_terraformed.go
+++ b/apis/dli/v1beta1/zz_generated_terraformed.go
@@ -151,6 +151,7 @@ func (tr *FlinksqlJob) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("ResumeMaxNum"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/dli/config.go
+++ b/config/dli/config.go
@@ -10,10 +10,25 @@ import (
 // Configure configures individual resources by adding custom ResourceConfigurators.
 func Configure(p *config.Provider) {
 
+	// flexibleengine_dli_flinksql_job
+	// https://registry.terraform.io/providers/FlexibleEngineCloud/flexibleengine/latest/docs/resources/dli_flinksql_job
 	p.AddResourceConfigurator("flexibleengine_dli_flinksql_job", func(r *config.Resource) {
+
 		r.References["smn_topic"] = config.Reference{
 			Type: tools.GenerateType("smn", "Topic"),
 		}
+
+		r.References["obs_bucket"] = config.Reference{
+			Type: tools.GenerateType("oss", "OBSBucket"),
+		}
+
+		r.LateInitializer = config.LateInitializer{
+			IgnoredFields: []string{"resume_max_num"},
+		}
+
+		// This value generate loop destroy
+		config.MarkAsRequired(r.TerraformResource, "resume_max_num")
+
 	})
 
 	p.AddResourceConfigurator("flexibleengine_dli_table", func(r *config.Resource) {
@@ -22,28 +37,23 @@ func Configure(p *config.Provider) {
 		}
 	})
 
-	// flexibleengine_dli_spark_job
 	p.AddResourceConfigurator("flexibleengine_dli_spark_job", func(r *config.Resource) {
 		r.References["queue_name"] = config.Reference{
 			Type: "Queue",
 		}
 
-		// app_name
 		r.References["app_name"] = config.Reference{
 			Type: "DLIPackage",
 		}
 
-		// jars
 		r.References["jars"] = config.Reference{
 			Type: "DLIPackage",
 		}
 
-		// python_files
 		r.References["python_files"] = config.Reference{
 			Type: "DLIPackage",
 		}
 
-		// files
 		r.References["files"] = config.Reference{
 			Type: "DLIPackage",
 		}

--- a/examples/dli/flinksqljob.yaml
+++ b/examples/dli/flinksqljob.yaml
@@ -10,6 +10,7 @@ spec:
   forProvider:
     name: example-dli-flinksqljob
     type: flink_sql_job
+    resumeMaxNum: -1
     sql: |
       CREATE SOURCE STREAM car_infos (
         car_id STRING,

--- a/examples/dli/table.yaml
+++ b/examples/dli/table.yaml
@@ -1,0 +1,25 @@
+apiVersion: dli.flexibleengine.upbound.io/v1beta1
+kind: Table
+metadata:
+  annotations:
+    meta.upbound.io/example-id: dli/v1beta1/table
+  labels:
+    testing.upbound.io/example-name: example_dli_table
+  name: example-dli-table
+spec:
+  forProvider:
+    bucketLocation: obs://example-dlipackageextra-obsbucket/user/data/user.csv
+    columns:
+      - description: person name
+        name: name
+        type: string
+      - description: home address
+        name: address
+        type: string
+    dataFormat: csv
+    dataLocation: OBS
+    databaseNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example_dli_database
+    description: dli table test
+    name: exampledlitable

--- a/examples/dli/table.yaml.extra
+++ b/examples/dli/table.yaml.extra
@@ -1,0 +1,31 @@
+apiVersion: oss.flexibleengine.upbound.io/v1beta1
+kind: OBSBucket
+metadata:
+  annotations:
+    meta.upbound.io/example-id: oss/v1beta1/obsbucket
+  labels:
+    testing.upbound.io/example-name: example_dlitableextra_obsbucket
+  name: example-dlipackageextra-obsbucket
+spec:
+  forProvider:
+    acl: private
+    bucket: example-dlipackageextra-obsbucket
+
+---
+
+apiVersion: oss.flexibleengine.upbound.io/v1beta1
+kind: OBSBucketObject
+metadata:
+  annotations:
+    meta.upbound.io/example-id: oss/v1beta1/obsbucketobject
+  labels:
+    testing.upbound.io/example-name: example_dlitableextra_obsbucketobject
+  name: example-dlitableextra-obsbucketobject
+spec:
+  forProvider:
+    bucketSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example_dlitableextra_obsbucket
+    contentType: text/plain
+    key: user/data/user.csv
+    content: Jason,Tokyo

--- a/package/crds/dli.flexibleengine.upbound.io_flinksqljobs.yaml
+++ b/package/crds/dli.flexibleengine.upbound.io_flinksqljobs.yaml
@@ -115,6 +115,79 @@ spec:
                       the snapshot. This parameter is valid only when log_enabled
                       is set to true.
                     type: string
+                  obsBucketRef:
+                    description: Reference to a OBSBucket in oss to populate obsBucket.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: Resolution specifies whether resolution of
+                              this reference is required. The default is 'Required',
+                              which means the reconcile will fail if the reference
+                              cannot be resolved. 'Optional' means this reference
+                              will be a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: Resolve specifies when this reference should
+                              be resolved. The default is 'IfNotPresent', which will
+                              attempt to resolve the reference only when the corresponding
+                              field is not present. Use 'Always' to resolve the reference
+                              on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  obsBucketSelector:
+                    description: Selector for a OBSBucket in oss to populate obsBucket.
+                    properties:
+                      matchControllerRef:
+                        description: MatchControllerRef ensures an object with the
+                          same controller reference as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: Resolution specifies whether resolution of
+                              this reference is required. The default is 'Required',
+                              which means the reconcile will fail if the reference
+                              cannot be resolved. 'Optional' means this reference
+                              will be a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: Resolve specifies when this reference should
+                              be resolved. The default is 'IfNotPresent', which will
+                              attempt to resolve the reference only when the corresponding
+                              field is not present. Use 'Always' to resolve the reference
+                              on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   parallelNumber:
                     description: Specifies number of parallel for a job. The default
                       value is 1.
@@ -259,6 +332,7 @@ spec:
                     type: string
                 required:
                 - name
+                - resumeMaxNum
                 type: object
               providerConfigRef:
                 default:


### PR DESCRIPTION
### Description of your changes

Fixes #26 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```
NAME                                                            READY   SYNCED   EXTERNAL-NAME               AGE
stream.dis.flexibleengine.upbound.io/example-dis-streaminput    True    True     example-dis-stream-input    6h10m
stream.dis.flexibleengine.upbound.io/example-dis-streamoutput   True    True     example-dis-stream-output   6h10m

NAME                                                    READY   SYNCED   EXTERNAL-NAME            AGE
queue.dli.flexibleengine.upbound.io/example-dli-queue   True    True     example_dli_queue_test   6h11m

NAME                                                                READY   SYNCED   EXTERNAL-NAME   AGE
flinksqljob.dli.flexibleengine.upbound.io/example-dli-flinksqljob   True    True     17124           5h33m

NAME                                                          READY   SYNCED   EXTERNAL-NAME   AGE
sparkjob.dli.flexibleengine.upbound.io/example-dli-sparkjob   False   True                     39m

NAME                                                           READY   SYNCED   EXTERNAL-NAME                              AGE
dlipackage.dli.flexibleengine.upbound.io/example-dli-package   True    True     example-dli-package-group/object_file.py   6h10m

NAME                                                    READY   SYNCED   EXTERNAL-NAME                        AGE
table.dli.flexibleengine.upbound.io/example-dli-table   True    True     exampledlidatabase/exampledlitable   6h48m

NAME                                                          READY   SYNCED   EXTERNAL-NAME        AGE
database.dli.flexibleengine.upbound.io/example-dli-database   True    True     exampledlidatabase   6h48m

NAME                                                                                    READY   SYNCED   EXTERNAL-NAME                 AGE
obsbucketobject.oss.flexibleengine.upbound.io/example-dlipackageextra-obsbucketobject   True    True     dli/packages/object_file.py   6h10m
obsbucketobject.oss.flexibleengine.upbound.io/example-dlitableextra-obsbucketobject     True    True     user/data/user.csv            6h48m
```

### INFO

`sparkjob` is not ready because a python script spark (Copy from terraform provider used in unit test) not working but the resource is created successfully.

```
NAME                                                          READY   SYNCED   EXTERNAL-NAME   AGE
sparkjob.dli.flexibleengine.upbound.io/example-dli-sparkjob   False   True                     40m
```