### PR TITLE
refactor!: standardize Refs/Selector FieldsName

### DIFF
--- a/apis/agd/v1beta1/zz_instance_types.go
+++ b/apis/agd/v1beta1/zz_instance_types.go
@@ -130,6 +130,8 @@ type InstanceParameters struct {
 	// belongs to.
 	// The ID of the security group to which the dedicated instance belongs to.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.SecurityGroup
+	// +crossplane:generate:reference:refFieldName=SecurityGroupIDRef
+	// +crossplane:generate:reference:selectorFieldName=SecurityGroupIDSelector
 	// +kubebuilder:validation:Optional
 	SecurityGroupID *string `json:"securityGroupId,omitempty" tf:"security_group_id,omitempty"`
 
@@ -146,6 +148,8 @@ type InstanceParameters struct {
 	// The ID of the VPC subnet used to create the dedicated instance.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
 	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
+	// +crossplane:generate:reference:refFieldName=SubnetIDRef
+	// +crossplane:generate:reference:selectorFieldName=SubnetIDSelector
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/cce/v1beta1/zz_cluster_types.go
+++ b/apis/cce/v1beta1/zz_cluster_types.go
@@ -175,6 +175,8 @@ type ClusterParameters struct {
 	// Changing this parameter will create a new cluster resource.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
 	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
+	// +crossplane:generate:reference:refFieldName=SubnetIDRef
+	// +crossplane:generate:reference:selectorFieldName=SubnetIDSelector
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/cce/v1beta1/zz_node_types.go
+++ b/apis/cce/v1beta1/zz_node_types.go
@@ -224,6 +224,8 @@ type NodeParameters struct {
 	// Changing this parameter will create a new resource.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
 	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
+	// +crossplane:generate:reference:refFieldName=SubnetIDRef
+	// +crossplane:generate:reference:selectorFieldName=SubnetIDSelector
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/cce/v1beta1/zz_nodepool_types.go
+++ b/apis/cce/v1beta1/zz_nodepool_types.go
@@ -190,6 +190,8 @@ type NodePoolParameters struct {
 	// Changing this parameter will create a new resource.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
 	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
+	// +crossplane:generate:reference:refFieldName=SubnetIDRef
+	// +crossplane:generate:reference:selectorFieldName=SubnetIDSelector
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/dcs/v1beta1/zz_instance_types.go
+++ b/apis/dcs/v1beta1/zz_instance_types.go
@@ -139,6 +139,8 @@ type InstanceParameters struct {
 	// Specifies the ID of the VPC subnet. Changing this creates a new instance.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
 	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
+	// +crossplane:generate:reference:refFieldName=NetworkIDRef
+	// +crossplane:generate:reference:selectorFieldName=NetworkIDSelector
 	// +kubebuilder:validation:Optional
 	NetworkID *string `json:"networkId,omitempty" tf:"network_id,omitempty"`
 
@@ -179,6 +181,8 @@ type InstanceParameters struct {
 	// Specifies the id of the security group which the instance belongs to.
 	// This parameter is only supported and mandatory for Memcached and Redis 3.0 versions.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.SecurityGroup
+	// +crossplane:generate:reference:refFieldName=SecurityGroupIDRef
+	// +crossplane:generate:reference:selectorFieldName=SecurityGroupIDSelector
 	// +kubebuilder:validation:Optional
 	SecurityGroupID *string `json:"securityGroupId,omitempty" tf:"security_group_id,omitempty"`
 

--- a/apis/dds/v1beta1/zz_instance_types.go
+++ b/apis/dds/v1beta1/zz_instance_types.go
@@ -147,6 +147,8 @@ type InstanceParameters struct {
 	// Specifies the security group ID of the DDS instance.
 	// Changing this creates a new instance.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.SecurityGroup
+	// +crossplane:generate:reference:refFieldName=SecurityGroupIDRef
+	// +crossplane:generate:reference:selectorFieldName=SecurityGroupIDSelector
 	// +kubebuilder:validation:Optional
 	SecurityGroupID *string `json:"securityGroupId,omitempty" tf:"security_group_id,omitempty"`
 
@@ -161,6 +163,8 @@ type InstanceParameters struct {
 	// Specifies the ID of the VPC Subnet. Changing this creates a new instance.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
 	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
+	// +crossplane:generate:reference:refFieldName=SubnetIDRef
+	// +crossplane:generate:reference:selectorFieldName=SubnetIDSelector
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/dedicatedelb/v1beta1/zz_generated.resolvers.go
+++ b/apis/dedicatedelb/v1beta1/zz_generated.resolvers.go
@@ -147,7 +147,7 @@ func (mg *LoadBalancer) ResolveReferences(ctx context.Context, c client.Reader) 
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.IPv4SubnetID),
-		Extract:      reference.ExternalName(),
+		Extract:      tools.ExtractorParamPathfunc(true, "ipv4_subnet_id"),
 		Reference:    mg.Spec.ForProvider.IPv4SubnetIDRef,
 		Selector:     mg.Spec.ForProvider.IPv4SubnetIDSelector,
 		To: reference.To{
@@ -221,7 +221,7 @@ func (mg *Member) ResolveReferences(ctx context.Context, c client.Reader) error 
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.SubnetID),
-		Extract:      reference.ExternalName(),
+		Extract:      tools.ExtractorParamPathfunc(true, "ipv4_subnet_id"),
 		Reference:    mg.Spec.ForProvider.SubnetIDRef,
 		Selector:     mg.Spec.ForProvider.SubnetIDSelector,
 		To: reference.To{

--- a/apis/dedicatedelb/v1beta1/zz_loadbalancer_types.go
+++ b/apis/dedicatedelb/v1beta1/zz_loadbalancer_types.go
@@ -90,6 +90,7 @@ type LoadBalancerParameters struct {
 	// VPC Subnet on which to allocate the loadbalancer's ipv4 address.
 	// the IPv4 subnet ID of the subnet where the load balancer resides
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "ipv4_subnet_id")
 	// +kubebuilder:validation:Optional
 	IPv4SubnetID *string `json:"ipv4SubnetId,omitempty" tf:"ipv4_subnet_id,omitempty"`
 

--- a/apis/dedicatedelb/v1beta1/zz_member_types.go
+++ b/apis/dedicatedelb/v1beta1/zz_member_types.go
@@ -61,6 +61,7 @@ type MemberParameters struct {
 	// must be TCP, HTTP, or HTTPS.
 	// The IPv4 or IPv6 subnet ID of the subnet in which to access the member
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "ipv4_subnet_id")
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/dms/v1beta1/zz_kafkainstance_types.go
+++ b/apis/dms/v1beta1/zz_kafkainstance_types.go
@@ -133,6 +133,8 @@ type KafkaInstanceParameters struct {
 	// Changing this creates a new instance resource.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
 	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
+	// +crossplane:generate:reference:refFieldName=NetworkIDRef
+	// +crossplane:generate:reference:selectorFieldName=NetworkIDSelector
 	// +kubebuilder:validation:Optional
 	NetworkID *string `json:"networkId,omitempty" tf:"network_id,omitempty"`
 
@@ -164,6 +166,8 @@ type KafkaInstanceParameters struct {
 
 	// Specifies the ID of a security group.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.SecurityGroup
+	// +crossplane:generate:reference:refFieldName=SecurityGroupIDRef
+	// +crossplane:generate:reference:selectorFieldName=SecurityGroupIDSelector
 	// +kubebuilder:validation:Optional
 	SecurityGroupID *string `json:"securityGroupId,omitempty" tf:"security_group_id,omitempty"`
 

--- a/apis/dms/v1beta1/zz_rocketmqinstance_types.go
+++ b/apis/dms/v1beta1/zz_rocketmqinstance_types.go
@@ -149,6 +149,8 @@ type RocketMQInstanceParameters struct {
 
 	// Specifies the ID of a security group
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.SecurityGroup
+	// +crossplane:generate:reference:refFieldName=SecurityGroupIDRef
+	// +crossplane:generate:reference:selectorFieldName=SecurityGroupIDSelector
 	// +kubebuilder:validation:Optional
 	SecurityGroupID *string `json:"securityGroupId,omitempty" tf:"security_group_id,omitempty"`
 
@@ -171,6 +173,8 @@ type RocketMQInstanceParameters struct {
 	// Specifies the ID of a subnet
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
 	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
+	// +crossplane:generate:reference:refFieldName=SubnetIDRef
+	// +crossplane:generate:reference:selectorFieldName=SubnetIDSelector
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/dws/v1beta1/zz_cluster_types.go
+++ b/apis/dws/v1beta1/zz_cluster_types.go
@@ -97,6 +97,8 @@ type ClusterParameters struct {
 	// The ID of the VPC Subnet, which is used for configuring cluster network.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
 	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
+	// +crossplane:generate:reference:refFieldName=SubnetIDRef
+	// +crossplane:generate:reference:selectorFieldName=SubnetIDSelector
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/eip/v1beta1/zz_eipassociate_types.go
+++ b/apis/eip/v1beta1/zz_eipassociate_types.go
@@ -36,6 +36,8 @@ type EIPAssociateParameters struct {
 	// It is mandatory when fixed_ip is set. Changing this creates a new resource.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
 	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
+	// +crossplane:generate:reference:refFieldName=NetworkIDRef
+	// +crossplane:generate:reference:selectorFieldName=NetworkIDSelector
 	// +kubebuilder:validation:Optional
 	NetworkID *string `json:"networkId,omitempty" tf:"network_id,omitempty"`
 

--- a/apis/elb/v1beta1/zz_generated.resolvers.go
+++ b/apis/elb/v1beta1/zz_generated.resolvers.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	v1beta1 "github.com/FrangipaneTeam/provider-flexibleengine/apis/iam/v1beta1"
 	v1beta11 "github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1"
+	tools "github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
 	errors "github.com/pkg/errors"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
@@ -272,7 +273,7 @@ func (mg *Member) ResolveReferences(ctx context.Context, c client.Reader) error 
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.SubnetID),
-		Extract:      reference.ExternalName(),
+		Extract:      tools.ExtractorParamPathfunc(true, "id"),
 		Reference:    mg.Spec.ForProvider.SubnetIDRef,
 		Selector:     mg.Spec.ForProvider.SubnetIDSelector,
 		To: reference.To{

--- a/apis/elb/v1beta1/zz_member_types.go
+++ b/apis/elb/v1beta1/zz_member_types.go
@@ -64,6 +64,9 @@ type MemberParameters struct {
 	// The ipv4_subnet_id or ipv6_subnet_id of the
 	// VPC Subnet in which to access the member
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
+	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
+	// +crossplane:generate:reference:refFieldName=SubnetIDRef
+	// +crossplane:generate:reference:selectorFieldName=SubnetIDSelector
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/fgs/v1beta1/zz_function_types.go
+++ b/apis/fgs/v1beta1/zz_function_types.go
@@ -170,6 +170,8 @@ type FunctionParameters struct {
 	// Specifies the network ID of subnet.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
 	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
+	// +crossplane:generate:reference:refFieldName=NetworkIDRef
+	// +crossplane:generate:reference:selectorFieldName=NetworkIDSelector
 	// +kubebuilder:validation:Optional
 	NetworkID *string `json:"networkId,omitempty" tf:"network_id,omitempty"`
 

--- a/apis/mrs/v1beta1/zz_cluster_types.go
+++ b/apis/mrs/v1beta1/zz_cluster_types.go
@@ -273,8 +273,19 @@ type ClusterParameters struct {
 	// +kubebuilder:validation:Optional
 	SafeMode *bool `json:"safeMode,omitempty" tf:"safe_mode,omitempty"`
 
+	// References to SecurityGroup in vpc to populate securityGroupIds.
+	// +kubebuilder:validation:Optional
+	SecurityGroupIDRefs []v1.Reference `json:"securityGroupIdRefs,omitempty" tf:"-"`
+
+	// Selector for a list of SecurityGroup in vpc to populate securityGroupIds.
+	// +kubebuilder:validation:Optional
+	SecurityGroupIDSelector *v1.Selector `json:"securityGroupIdSelector,omitempty" tf:"-"`
+
 	// Specifies an array of one or more security group ID to attach to the
 	// MRS cluster. If using the specified security group, the group need to open the specified port (9022) rules.
+	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.SecurityGroup
+	// +crossplane:generate:reference:refFieldName=SecurityGroupIDRefs
+	// +crossplane:generate:reference:selectorFieldName=SecurityGroupIDSelector
 	// +kubebuilder:validation:Optional
 	SecurityGroupIds []*string `json:"securityGroupIds,omitempty" tf:"security_group_ids,omitempty"`
 
@@ -294,6 +305,8 @@ type ClusterParameters struct {
 	// Changing this will create a new MRS cluster resource.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
 	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
+	// +crossplane:generate:reference:refFieldName=SubnetIDRef
+	// +crossplane:generate:reference:selectorFieldName=SubnetIDSelector
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/mrs/v1beta1/zz_generated.deepcopy.go
+++ b/apis/mrs/v1beta1/zz_generated.deepcopy.go
@@ -440,6 +440,18 @@ func (in *ClusterParameters) DeepCopyInto(out *ClusterParameters) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.SecurityGroupIDRefs != nil {
+		in, out := &in.SecurityGroupIDRefs, &out.SecurityGroupIDRefs
+		*out = make([]v1.Reference, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.SecurityGroupIDSelector != nil {
+		in, out := &in.SecurityGroupIDSelector, &out.SecurityGroupIDSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.SecurityGroupIds != nil {
 		in, out := &in.SecurityGroupIds, &out.SecurityGroupIds
 		*out = make([]*string, len(*in))

--- a/apis/nat/v1beta1/zz_gateway_types.go
+++ b/apis/nat/v1beta1/zz_gateway_types.go
@@ -55,6 +55,8 @@ type GatewayParameters struct {
 	// (the next hop of the DVR) of the NAT gateway. Changing this creates a new nat gateway.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
 	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
+	// +crossplane:generate:reference:refFieldName=SubnetIDRef
+	// +crossplane:generate:reference:selectorFieldName=SubnetIDSelector
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/nat/v1beta1/zz_snatrule_types.go
+++ b/apis/nat/v1beta1/zz_snatrule_types.go
@@ -63,6 +63,8 @@ type SnatRuleParameters struct {
 	// The resource ID in UUID format.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
 	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
+	// +crossplane:generate:reference:refFieldName=NetworkIDRef
+	// +crossplane:generate:reference:selectorFieldName=NetworkIDSelector
 	// +kubebuilder:validation:Optional
 	NetworkID *string `json:"networkId,omitempty" tf:"network_id,omitempty"`
 
@@ -91,6 +93,8 @@ type SnatRuleParameters struct {
 	// This parameter and cidr are alternative. Changing this creates a new snat rule.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
 	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
+	// +crossplane:generate:reference:refFieldName=SubnetIDRef
+	// +crossplane:generate:reference:selectorFieldName=SubnetIDSelector
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/netacl/v1beta1/zz_acl_types.go
+++ b/apis/netacl/v1beta1/zz_acl_types.go
@@ -75,17 +75,17 @@ type ACLParameters struct {
 
 	// References to VPCSubnet in vpc to populate subnets.
 	// +kubebuilder:validation:Optional
-	SubnetRefs []v1.Reference `json:"subnetRefs,omitempty" tf:"-"`
+	SubnetIDRefs []v1.Reference `json:"subnetIdRefs,omitempty" tf:"-"`
 
 	// Selector for a list of VPCSubnet in vpc to populate subnets.
 	// +kubebuilder:validation:Optional
-	SubnetSelector *v1.Selector `json:"subnetSelector,omitempty" tf:"-"`
+	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 
 	// A list of the IDs of networks associated with the network ACL.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
 	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
-	// +crossplane:generate:reference:refFieldName=SubnetRefs
-	// +crossplane:generate:reference:selectorFieldName=SubnetSelector
+	// +crossplane:generate:reference:refFieldName=SubnetIDRefs
+	// +crossplane:generate:reference:selectorFieldName=SubnetIDSelector
 	// +kubebuilder:validation:Optional
 	Subnets []*string `json:"subnets,omitempty" tf:"subnets,omitempty"`
 }

--- a/apis/netacl/v1beta1/zz_generated.deepcopy.go
+++ b/apis/netacl/v1beta1/zz_generated.deepcopy.go
@@ -178,15 +178,15 @@ func (in *ACLParameters) DeepCopyInto(out *ACLParameters) {
 			}
 		}
 	}
-	if in.SubnetRefs != nil {
-		in, out := &in.SubnetRefs, &out.SubnetRefs
+	if in.SubnetIDRefs != nil {
+		in, out := &in.SubnetIDRefs, &out.SubnetIDRefs
 		*out = make([]v1.Reference, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.SubnetSelector != nil {
-		in, out := &in.SubnetSelector, &out.SubnetSelector
+	if in.SubnetIDSelector != nil {
+		in, out := &in.SubnetIDSelector, &out.SubnetIDSelector
 		*out = new(v1.Selector)
 		(*in).DeepCopyInto(*out)
 	}

--- a/apis/netacl/v1beta1/zz_generated.resolvers.go
+++ b/apis/netacl/v1beta1/zz_generated.resolvers.go
@@ -56,8 +56,8 @@ func (mg *ACL) ResolveReferences(ctx context.Context, c client.Reader) error {
 	mrsp, err = r.ResolveMultiple(ctx, reference.MultiResolutionRequest{
 		CurrentValues: reference.FromPtrValues(mg.Spec.ForProvider.Subnets),
 		Extract:       tools.ExtractorParamPathfunc(true, "id"),
-		References:    mg.Spec.ForProvider.SubnetRefs,
-		Selector:      mg.Spec.ForProvider.SubnetSelector,
+		References:    mg.Spec.ForProvider.SubnetIDRefs,
+		Selector:      mg.Spec.ForProvider.SubnetIDSelector,
 		To: reference.To{
 			List:    &v1beta1.VPCSubnetList{},
 			Managed: &v1beta1.VPCSubnet{},
@@ -67,7 +67,7 @@ func (mg *ACL) ResolveReferences(ctx context.Context, c client.Reader) error {
 		return errors.Wrap(err, "mg.Spec.ForProvider.Subnets")
 	}
 	mg.Spec.ForProvider.Subnets = reference.ToPtrValues(mrsp.ResolvedValues)
-	mg.Spec.ForProvider.SubnetRefs = mrsp.ResolvedReferences
+	mg.Spec.ForProvider.SubnetIDRefs = mrsp.ResolvedReferences
 
 	return nil
 }

--- a/apis/rds/v1beta1/zz_instance_types.go
+++ b/apis/rds/v1beta1/zz_instance_types.go
@@ -166,6 +166,8 @@ type InstanceParameters struct {
 
 	// Specifies the security group which the RDS DB instance belongs to.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.SecurityGroup
+	// +crossplane:generate:reference:refFieldName=SecurityGroupIDRef
+	// +crossplane:generate:reference:selectorFieldName=SecurityGroupIDSelector
 	// +kubebuilder:validation:Optional
 	SecurityGroupID *string `json:"securityGroupId,omitempty" tf:"security_group_id,omitempty"`
 
@@ -181,6 +183,8 @@ type InstanceParameters struct {
 	// Changing this parameter will create a new resource.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
 	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
+	// +crossplane:generate:reference:refFieldName=SubnetIDRef
+	// +crossplane:generate:reference:selectorFieldName=SubnetIDSelector
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/sfs/v1beta1/zz_turbo_types.go
+++ b/apis/sfs/v1beta1/zz_turbo_types.go
@@ -63,6 +63,8 @@ type TurboParameters struct {
 
 	// Specifies the security group ID. Changing this will create a new resource.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.SecurityGroup
+	// +crossplane:generate:reference:refFieldName=SecurityGroupIDRef
+	// +crossplane:generate:reference:selectorFieldName=SecurityGroupIDSelector
 	// +kubebuilder:validation:Optional
 	SecurityGroupID *string `json:"securityGroupId,omitempty" tf:"security_group_id,omitempty"`
 
@@ -91,6 +93,8 @@ type TurboParameters struct {
 	// Specifies the ID of the VPC Subnet. Changing this will create a new resource.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
 	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
+	// +crossplane:generate:reference:refFieldName=SubnetIDRef
+	// +crossplane:generate:reference:selectorFieldName=SubnetIDSelector
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/apis/vpc/v1beta1/zz_generated.deepcopy.go
+++ b/apis/vpc/v1beta1/zz_generated.deepcopy.go
@@ -612,6 +612,18 @@ func (in *PortParameters) DeepCopyInto(out *PortParameters) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.SecurityGroupIDRefs != nil {
+		in, out := &in.SecurityGroupIDRefs, &out.SecurityGroupIDRefs
+		*out = make([]v1.Reference, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.SecurityGroupIDSelector != nil {
+		in, out := &in.SecurityGroupIDSelector, &out.SecurityGroupIDSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.SecurityGroupIds != nil {
 		in, out := &in.SecurityGroupIds, &out.SecurityGroupIds
 		*out = make([]*string, len(*in))
@@ -991,8 +1003,15 @@ func (in *RouteTableParameters) DeepCopyInto(out *RouteTableParameters) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.SubnetSelector != nil {
-		in, out := &in.SubnetSelector, &out.SubnetSelector
+	if in.SubnetIDRefs != nil {
+		in, out := &in.SubnetIDRefs, &out.SubnetIDRefs
+		*out = make([]v1.Reference, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.SubnetIDSelector != nil {
+		in, out := &in.SubnetIDSelector, &out.SubnetIDSelector
 		*out = new(v1.Selector)
 		(*in).DeepCopyInto(*out)
 	}
@@ -1005,13 +1024,6 @@ func (in *RouteTableParameters) DeepCopyInto(out *RouteTableParameters) {
 				*out = new(string)
 				**out = **in
 			}
-		}
-	}
-	if in.SubnetsRefs != nil {
-		in, out := &in.SubnetsRefs, &out.SubnetsRefs
-		*out = make([]v1.Reference, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.VPCID != nil {

--- a/apis/vpc/v1beta1/zz_port_types.go
+++ b/apis/vpc/v1beta1/zz_port_types.go
@@ -108,6 +108,8 @@ type PortParameters struct {
 	// this creates a new port.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
 	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
+	// +crossplane:generate:reference:refFieldName=NetworkIDRef
+	// +crossplane:generate:reference:selectorFieldName=NetworkIDSelector
 	// +kubebuilder:validation:Optional
 	NetworkID *string `json:"networkId,omitempty" tf:"network_id,omitempty"`
 
@@ -124,9 +126,20 @@ type PortParameters struct {
 	// +kubebuilder:validation:Optional
 	Region *string `json:"region,omitempty" tf:"region,omitempty"`
 
+	// References to SecurityGroup in vpc to populate securityGroupIds.
+	// +kubebuilder:validation:Optional
+	SecurityGroupIDRefs []v1.Reference `json:"securityGroupIdRefs,omitempty" tf:"-"`
+
+	// Selector for a list of SecurityGroup in vpc to populate securityGroupIds.
+	// +kubebuilder:validation:Optional
+	SecurityGroupIDSelector *v1.Selector `json:"securityGroupIdSelector,omitempty" tf:"-"`
+
 	// A list of security group IDs to apply to the
 	// port. The security groups must be specified by ID and not name (as opposed
 	// to how they are configured with the Compute Instance).
+	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.SecurityGroup
+	// +crossplane:generate:reference:refFieldName=SecurityGroupIDRefs
+	// +crossplane:generate:reference:selectorFieldName=SecurityGroupIDSelector
 	// +kubebuilder:validation:Optional
 	SecurityGroupIds []*string `json:"securityGroupIds,omitempty" tf:"security_group_ids,omitempty"`
 

--- a/apis/vpc/v1beta1/zz_routetable_types.go
+++ b/apis/vpc/v1beta1/zz_routetable_types.go
@@ -41,20 +41,21 @@ type RouteTableParameters struct {
 	// +kubebuilder:validation:Optional
 	Route []RouteTableRouteParameters `json:"route,omitempty" tf:"route,omitempty"`
 
-	// Selector for a list of VPCSubnet to populate subnets.
+	// References to VPCSubnet in vpc to populate subnets.
 	// +kubebuilder:validation:Optional
-	SubnetSelector *v1.Selector `json:"subnetSelector,omitempty" tf:"-"`
+	SubnetIDRefs []v1.Reference `json:"subnetIdRefs,omitempty" tf:"-"`
+
+	// Selector for a list of VPCSubnet in vpc to populate subnets.
+	// +kubebuilder:validation:Optional
+	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 
 	// Specifies an array of one or more subnets associating with the route table.
-	// +crossplane:generate:reference:type=VPCSubnet
+	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
 	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
-	// +crossplane:generate:reference:selectorFieldName=SubnetSelector
+	// +crossplane:generate:reference:refFieldName=SubnetIDRefs
+	// +crossplane:generate:reference:selectorFieldName=SubnetIDSelector
 	// +kubebuilder:validation:Optional
 	Subnets []*string `json:"subnets,omitempty" tf:"subnets,omitempty"`
-
-	// References to VPCSubnet to populate subnets.
-	// +kubebuilder:validation:Optional
-	SubnetsRefs []v1.Reference `json:"subnetsRefs,omitempty" tf:"-"`
 
 	// Specifies the VPC ID for which a route table is to be added.
 	// Changing this creates a new resource.

--- a/apis/vpc/v1beta1/zz_securitygrouprule_types.go
+++ b/apis/vpc/v1beta1/zz_securitygrouprule_types.go
@@ -84,6 +84,8 @@ type SecurityGroupRuleParameters struct {
 	// The security group ID the rule should belong
 	// to. Changing this creates a new security group rule.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.SecurityGroup
+	// +crossplane:generate:reference:refFieldName=SecurityGroupIDRef
+	// +crossplane:generate:reference:selectorFieldName=SecurityGroupIDSelector
 	// +kubebuilder:validation:Optional
 	SecurityGroupID *string `json:"securityGroupId,omitempty" tf:"security_group_id,omitempty"`
 

--- a/apis/vpc/v1beta1/zz_vip_types.go
+++ b/apis/vpc/v1beta1/zz_vip_types.go
@@ -51,6 +51,8 @@ type VIPParameters struct {
 	// Changing this will create a new VIP resource.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
 	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
+	// +crossplane:generate:reference:refFieldName=NetworkIDRef
+	// +crossplane:generate:reference:selectorFieldName=NetworkIDSelector
 	// +kubebuilder:validation:Optional
 	NetworkID *string `json:"networkId,omitempty" tf:"network_id,omitempty"`
 

--- a/apis/vpcep/v1beta1/zz_endpoint_types.go
+++ b/apis/vpcep/v1beta1/zz_endpoint_types.go
@@ -56,6 +56,8 @@ type EndpointParameters struct {
 	// Changing this creates a new VPC endpoint.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
 	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
+	// +crossplane:generate:reference:refFieldName=NetworkIDRef
+	// +crossplane:generate:reference:selectorFieldName=NetworkIDSelector
 	// +kubebuilder:validation:Optional
 	NetworkID *string `json:"networkId,omitempty" tf:"network_id,omitempty"`
 

--- a/apis/waf/v1beta1/zz_dedicatedinstance_types.go
+++ b/apis/waf/v1beta1/zz_dedicatedinstance_types.go
@@ -98,6 +98,8 @@ type DedicatedInstanceParameters struct {
 	// Changing this will create a new instance.
 	// +crossplane:generate:reference:type=github.com/FrangipaneTeam/provider-flexibleengine/apis/vpc/v1beta1.VPCSubnet
 	// +crossplane:generate:reference:extractor=github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools.ExtractorParamPathfunc(true, "id")
+	// +crossplane:generate:reference:refFieldName=SubnetIDRef
+	// +crossplane:generate:reference:selectorFieldName=SubnetIDSelector
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 

--- a/config/ag/config.go
+++ b/config/ag/config.go
@@ -17,8 +17,6 @@ func Configure(p *config.Provider) {
 			Type: "Group",
 		}
 
-		r.UseAsync = true
-
 	})
 
 }

--- a/config/as/config.go
+++ b/config/as/config.go
@@ -4,6 +4,7 @@ package as
 import (
 	"github.com/upbound/upjet/pkg/config"
 
+	"github.com/FrangipaneTeam/provider-flexibleengine/pkg/references"
 	"github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 )
 
@@ -43,14 +44,9 @@ func Configure(p *config.Provider) {
 		// 	Type:      tools.GenerateType("elb", "Listener"),
 		// 	Extractor: common.PathProtocolPortExtractor,
 		// }
-		r.References["security_groups.id"] = config.Reference{
-			Type: tools.GenerateType("vpc", "SecurityGroup"),
-		}
-		r.References["networks.id"] = config.Reference{
-			// Require Network ID of VPC Subnet
-			TerraformName: "flexibleengine_vpc_subnet_v1",
-			Extractor:     tools.GenerateExtractor(true, "id"),
-		}
+		r.References["security_groups.id"] = references.TypeSecurityGroupID().WithoutRefsSelectors().Get()
+
+		r.References["networks.id"] = references.TypeVPCSubnetID().WithoutRefsSelectors().Get()
 	})
 
 	// flexibleengine_as_lifecycle_hook_v1

--- a/config/dedicatedelb/config.go
+++ b/config/dedicatedelb/config.go
@@ -4,7 +4,7 @@ package dedicatedelb
 import (
 	"github.com/upbound/upjet/pkg/config"
 
-	"github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
+	"github.com/FrangipaneTeam/provider-flexibleengine/pkg/references"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.
@@ -35,29 +35,15 @@ func Configure(p *config.Provider) {
 	// flexibleengine_lb_loadbalancer_v3
 	// https://registry.terraform.io/providers/FlexibleEngineCloud/flexibleengine/latest/docs/resources/lb_loadbalancer_v3
 	p.AddResourceConfigurator("flexibleengine_lb_loadbalancer_v3", func(r *config.Resource) {
-		r.References["ipv4_subnet_id"] = config.Reference{
-			Type: tools.GenerateType("vpc", "VPCSubnet"),
-		}
-		r.References["ipv6_network_id"] = config.Reference{
-			Type:      tools.GenerateType("vpc", "VPCSubnet"),
-			Extractor: tools.GenerateExtractor(true, "id"),
-		}
-		r.References["ipv4_eip_id"] = config.Reference{
-			Type: tools.GenerateType("eip", "EIP"),
-		}
+		r.References["ipv4_subnet_id"] = references.TypeVPCSubnetIDIPV4().Get()
+
+		r.References["ipv6_network_id"] = references.TypeVPCSubnetID().WithoutRefsSelectors().Get()
 	})
 
 	// flexibleengine_lb_member_v3
 	// https://registry.terraform.io/providers/FlexibleEngineCloud/flexibleengine/latest/docs/resources/lb_member_v3
 	p.AddResourceConfigurator("flexibleengine_lb_member_v3", func(r *config.Resource) {
-		r.References["subnet_id"] = config.Reference{
-			Type: tools.GenerateType("vpc", "VPCSubnet"),
-		}
-	})
-
-	// flexibleengine_lb_monitor_v3
-	// https://registry.terraform.io/providers/FlexibleEngineCloud/flexibleengine/latest/docs/resources/lb_monitor_v3
-	p.AddResourceConfigurator("flexibleengine_lb_monitor_v3", func(r *config.Resource) {
+		r.References["subnet_id"] = references.TypeVPCSubnetIDIPV4().Get()
 	})
 
 	// flexibleengine_lb_pool_v3

--- a/config/elb/config.go
+++ b/config/elb/config.go
@@ -56,9 +56,9 @@ func Configure(p *config.Provider) {
 	// flexibleengine_lb_member_v2
 	// https://registry.terraform.io/providers/FlexibleEngineCloud/flexibleengine/latest/docs/resources/lb_member_v2
 	p.AddResourceConfigurator("flexibleengine_lb_member_v2", func(r *config.Resource) {
-		r.References["subnet_id"] = config.Reference{
-			Type: tools.GenerateType("vpc", "VPCSubnet"),
-		}
+		// r.References["subnet_id"] = config.Reference{
+		// 	Type: tools.GenerateType("vpc", "VPCSubnet"),
+		// }
 	})
 
 	// flexibleengine_lb_monitor_v2

--- a/config/mrs/config.go
+++ b/config/mrs/config.go
@@ -3,8 +3,6 @@ package mrs
 
 import (
 	"github.com/upbound/upjet/pkg/config"
-
-	"github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.
@@ -12,13 +10,6 @@ func Configure(p *config.Provider) {
 	// flexibleengine_mrs_cluster_v2
 	// https://registry.terraform.io/providers/FlexibleEngineCloud/flexibleengine/latest/docs/resources/mrs_cluster_v2
 	p.AddResourceConfigurator("flexibleengine_mrs_cluster_v2", func(r *config.Resource) {
-		r.UseAsync = true
-
-		// eip_id
-		r.References["eip_id"] = config.Reference{
-			Type: tools.GenerateType("eip", "EIP"),
-		}
-
 		// node_key_pair is sensitive ?
 		r.TerraformResource.Schema["node_key_pair"].Sensitive = true
 	})

--- a/config/netacl/config.go
+++ b/config/netacl/config.go
@@ -22,11 +22,5 @@ func Configure(p *config.Provider) {
 			SelectorFieldName: "OutboundRuleSelector",
 			RefFieldName:      "OutboundRuleRefs",
 		}
-		r.References["subnets"] = config.Reference{
-			Type:              tools.GenerateType("vpc", "VPCSubnet"),
-			Extractor:         tools.GenerateExtractor(true, "id"),
-			SelectorFieldName: "SubnetSelector",
-			RefFieldName:      "SubnetRefs",
-		}
 	})
 }

--- a/config/overrides.go
+++ b/config/overrides.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/upbound/upjet/pkg/config"
 
+	"github.com/FrangipaneTeam/provider-flexibleengine/pkg/references"
 	"github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 )
 
@@ -19,31 +20,38 @@ func KnownReferencers() config.ResourceOption { //nolint:gocyclo
 				continue
 			}
 			switch k {
-			// vpc_id is a reference to a Vpc resource
+
 			case "vpc_id":
-				r.References[k] = config.Reference{
-					Type: tools.GenerateType("vpc", "VPC"),
-				}
-			// subnet_id and network_id is a reference to a Subnet resource
-			case "subnet_id", "network_id":
-				r.References[k] = config.Reference{
-					Type:      tools.GenerateType("vpc", "VPCSubnet"),
-					Extractor: tools.GenerateExtractor(true, "id"),
-				}
-				// security_group_id is a reference to a SecurityGroup resource
-			case "security_group_id":
-				r.References[k] = config.Reference{
-					Type: tools.GenerateType("vpc", "SecurityGroup"),
-				}
-				// port_id is a reference to a NetworkPort resource
+				r.References[k] = references.TypeVPCID().Get()
+
+			case "subnet_id":
+				r.References[k] = references.TypeVPCSubnetID().Get()
+
+			case "subnet_ids", "subnets":
+				r.References[k] = references.TypeVPCSubnetID().WithCustomRefsSelectors("SubnetIDRefs", "SubnetIDSelector").Get()
+
+			case "network_id":
+				r.References[k] = references.TypeVPCSubnetID().WithCustomRefsSelectors("NetworkIDRef", "NetworkIDSelector").Get()
+
+			case "security_group_id", "security_group":
+				r.References[k] = references.TypeSecurityGroupID().Get()
+
+			case "security_group_ids":
+				r.References[k] = references.TypeSecurityGroupID().WithCustomRefsSelectors("SecurityGroupIDRefs", "SecurityGroupIDSelector").Get()
+
+			case "ipv4_eip_id", "eip_id":
+				r.References[k] = references.TypeEIPID().Get()
+
 			case "port_id":
 				r.References[k] = config.Reference{
 					Type: tools.GenerateType("vpc", "Port"),
 				}
+
 			case "tenant_id":
 				r.References[k] = config.Reference{
 					Type: tools.GenerateType("iam", "Project"),
 				}
+
 			case "instance_id":
 				switch r.ShortGroup {
 				case "dms":
@@ -61,15 +69,18 @@ func KnownReferencers() config.ResourceOption { //nolint:gocyclo
 						Type: tools.GenerateType("ecs", "Instance"),
 					}
 				}
+
 			case "image_name":
 				r.References[k] = config.Reference{
-					TerraformName: "flexibleengine_images_image_v2",
-					Extractor:     tools.GenerateExtractor(false, "image_name"),
+					Type:      tools.GenerateType("ims", "Image"),
+					Extractor: tools.GenerateExtractor(false, "image_name"),
 				}
+
 			case "image_id":
 				r.References[k] = config.Reference{
 					Type: tools.GenerateType("ims", "Image"),
 				}
+
 			case "pool_id":
 				switch r.ShortGroup {
 				case "elb":
@@ -81,6 +92,7 @@ func KnownReferencers() config.ResourceOption { //nolint:gocyclo
 						Type: tools.GenerateType("dedicatedelb", "Pool"),
 					}
 				}
+
 			case "policy_id":
 				if r.ShortGroup == "waf" {
 					r.References[k] = config.Reference{

--- a/config/sms/config.go
+++ b/config/sms/config.go
@@ -3,8 +3,6 @@ package sms
 
 import (
 	"github.com/upbound/upjet/pkg/config"
-
-	"github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.
@@ -14,20 +12,6 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("flexibleengine_sms_task", func(r *config.Resource) {
 		r.References["vm_template_id"] = config.Reference{
 			Type: "ServerTemplate",
-		}
-	})
-
-	p.AddResourceConfigurator("flexibleengine_sms_server_template", func(r *config.Resource) {
-		r.References["subnet_ids"] = config.Reference{
-			Type:              tools.GenerateType("vpc", "VPCSubnet"),
-			Extractor:         tools.GenerateExtractor(true, "id"),
-			RefFieldName:      "SubnetIDRefs",
-			SelectorFieldName: "SubnetIDSelector",
-		}
-		r.References["security_group_ids"] = config.Reference{
-			Type:              tools.GenerateType("vpc", "SecurityGroup"),
-			RefFieldName:      "SecurityGroupIDRefs",
-			SelectorFieldName: "SecurityGroupIDSelector",
 		}
 	})
 }

--- a/config/vpc/config.go
+++ b/config/vpc/config.go
@@ -3,8 +3,6 @@ package vpc
 
 import (
 	"github.com/upbound/upjet/pkg/config"
-
-	"github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.
@@ -15,11 +13,11 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("flexibleengine_vpc_route_table", func(r *config.Resource) {
 
 		// Subnets is a list of Subnet IDs
-		r.References["subnets"] = config.Reference{
-			Type:              "VPCSubnet",
-			Extractor:         tools.GenerateExtractor(true, "id"),
-			SelectorFieldName: "SubnetSelector", // Selector is only one reference
-		}
+		// r.References["subnets"] = config.Reference{
+		// 	Type:              "VPCSubnet",
+		// 	Extractor:         tools.GenerateExtractor(true, "id"),
+		// 	SelectorFieldName: "SubnetSelector", // Selector is only one reference
+		// }
 
 	})
 

--- a/examples-generated/netacl/acl.yaml
+++ b/examples-generated/netacl/acl.yaml
@@ -12,7 +12,7 @@ spec:
     - name: rule_1
     - name: rule_2
     name: my-fw-acl
-    subnetRefs:
+    subnetIdRefs:
     - name: flexibleengine_vpc_subnet_v1
 
 ---

--- a/examples/netacl/acl.yaml
+++ b/examples/netacl/acl.yaml
@@ -15,6 +15,6 @@ spec:
     outboundRuleRefs:
       - name: example-netacl-rule3
       - name: example-netacl-rule4
-    subnetRefs:
+    subnetIdRefs:
       - name: example-subnet
       - name: example-subnet2

--- a/package/crds/mrs.flexibleengine.upbound.io_clusters.yaml
+++ b/package/crds/mrs.flexibleengine.upbound.io_clusters.yaml
@@ -454,6 +454,83 @@ spec:
                     description: Specifies whether the running mode of the MRS cluster
                       is secure, default to true.
                     type: boolean
+                  securityGroupIdRefs:
+                    description: References to SecurityGroup in vpc to populate securityGroupIds.
+                    items:
+                      description: A Reference to a named object.
+                      properties:
+                        name:
+                          description: Name of the referenced object.
+                          type: string
+                        policy:
+                          description: Policies for referencing.
+                          properties:
+                            resolution:
+                              default: Required
+                              description: Resolution specifies whether resolution
+                                of this reference is required. The default is 'Required',
+                                which means the reconcile will fail if the reference
+                                cannot be resolved. 'Optional' means this reference
+                                will be a no-op if it cannot be resolved.
+                              enum:
+                              - Required
+                              - Optional
+                              type: string
+                            resolve:
+                              description: Resolve specifies when this reference should
+                                be resolved. The default is 'IfNotPresent', which
+                                will attempt to resolve the reference only when the
+                                corresponding field is not present. Use 'Always' to
+                                resolve the reference on every reconcile.
+                              enum:
+                              - Always
+                              - IfNotPresent
+                              type: string
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  securityGroupIdSelector:
+                    description: Selector for a list of SecurityGroup in vpc to populate
+                      securityGroupIds.
+                    properties:
+                      matchControllerRef:
+                        description: MatchControllerRef ensures an object with the
+                          same controller reference as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: Resolution specifies whether resolution of
+                              this reference is required. The default is 'Required',
+                              which means the reconcile will fail if the reference
+                              cannot be resolved. 'Optional' means this reference
+                              will be a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: Resolve specifies when this reference should
+                              be resolved. The default is 'IfNotPresent', which will
+                              attempt to resolve the reference only when the corresponding
+                              field is not present. Use 'Always' to resolve the reference
+                              on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   securityGroupIds:
                     description: Specifies an array of one or more security group
                       ID to attach to the MRS cluster. If using the specified security

--- a/package/crds/netacl.flexibleengine.upbound.io_acls.yaml
+++ b/package/crds/netacl.flexibleengine.upbound.io_acls.yaml
@@ -239,7 +239,7 @@ spec:
                     items:
                       type: string
                     type: array
-                  subnetRefs:
+                  subnetIdRefs:
                     description: References to VPCSubnet in vpc to populate subnets.
                     items:
                       description: A Reference to a named object.
@@ -276,7 +276,7 @@ spec:
                       - name
                       type: object
                     type: array
-                  subnetSelector:
+                  subnetIdSelector:
                     description: Selector for a list of VPCSubnet in vpc to populate
                       subnets.
                     properties:

--- a/package/crds/vpc.flexibleengine.upbound.io_ports.yaml
+++ b/package/crds/vpc.flexibleengine.upbound.io_ports.yaml
@@ -280,6 +280,83 @@ spec:
                       the region argument of the provider is used. Changing this creates
                       a new port.
                     type: string
+                  securityGroupIdRefs:
+                    description: References to SecurityGroup in vpc to populate securityGroupIds.
+                    items:
+                      description: A Reference to a named object.
+                      properties:
+                        name:
+                          description: Name of the referenced object.
+                          type: string
+                        policy:
+                          description: Policies for referencing.
+                          properties:
+                            resolution:
+                              default: Required
+                              description: Resolution specifies whether resolution
+                                of this reference is required. The default is 'Required',
+                                which means the reconcile will fail if the reference
+                                cannot be resolved. 'Optional' means this reference
+                                will be a no-op if it cannot be resolved.
+                              enum:
+                              - Required
+                              - Optional
+                              type: string
+                            resolve:
+                              description: Resolve specifies when this reference should
+                                be resolved. The default is 'IfNotPresent', which
+                                will attempt to resolve the reference only when the
+                                corresponding field is not present. Use 'Always' to
+                                resolve the reference on every reconcile.
+                              enum:
+                              - Always
+                              - IfNotPresent
+                              type: string
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  securityGroupIdSelector:
+                    description: Selector for a list of SecurityGroup in vpc to populate
+                      securityGroupIds.
+                    properties:
+                      matchControllerRef:
+                        description: MatchControllerRef ensures an object with the
+                          same controller reference as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: Resolution specifies whether resolution of
+                              this reference is required. The default is 'Required',
+                              which means the reconcile will fail if the reference
+                              cannot be resolved. 'Optional' means this reference
+                              will be a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: Resolve specifies when this reference should
+                              be resolved. The default is 'IfNotPresent', which will
+                              attempt to resolve the reference only when the corresponding
+                              field is not present. Use 'Always' to resolve the reference
+                              on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   securityGroupIds:
                     description: A list of security group IDs to apply to the port.
                       The security groups must be specified by ID and not name (as

--- a/package/crds/vpc.flexibleengine.upbound.io_routetables.yaml
+++ b/package/crds/vpc.flexibleengine.upbound.io_routetables.yaml
@@ -108,8 +108,46 @@ spec:
                       - type
                       type: object
                     type: array
-                  subnetSelector:
-                    description: Selector for a list of VPCSubnet to populate subnets.
+                  subnetIdRefs:
+                    description: References to VPCSubnet in vpc to populate subnets.
+                    items:
+                      description: A Reference to a named object.
+                      properties:
+                        name:
+                          description: Name of the referenced object.
+                          type: string
+                        policy:
+                          description: Policies for referencing.
+                          properties:
+                            resolution:
+                              default: Required
+                              description: Resolution specifies whether resolution
+                                of this reference is required. The default is 'Required',
+                                which means the reconcile will fail if the reference
+                                cannot be resolved. 'Optional' means this reference
+                                will be a no-op if it cannot be resolved.
+                              enum:
+                              - Required
+                              - Optional
+                              type: string
+                            resolve:
+                              description: Resolve specifies when this reference should
+                                be resolved. The default is 'IfNotPresent', which
+                                will attempt to resolve the reference only when the
+                                corresponding field is not present. Use 'Always' to
+                                resolve the reference on every reconcile.
+                              enum:
+                              - Always
+                              - IfNotPresent
+                              type: string
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  subnetIdSelector:
+                    description: Selector for a list of VPCSubnet in vpc to populate
+                      subnets.
                     properties:
                       matchControllerRef:
                         description: MatchControllerRef ensures an object with the
@@ -152,43 +190,6 @@ spec:
                       with the route table.
                     items:
                       type: string
-                    type: array
-                  subnetsRefs:
-                    description: References to VPCSubnet to populate subnets.
-                    items:
-                      description: A Reference to a named object.
-                      properties:
-                        name:
-                          description: Name of the referenced object.
-                          type: string
-                        policy:
-                          description: Policies for referencing.
-                          properties:
-                            resolution:
-                              default: Required
-                              description: Resolution specifies whether resolution
-                                of this reference is required. The default is 'Required',
-                                which means the reconcile will fail if the reference
-                                cannot be resolved. 'Optional' means this reference
-                                will be a no-op if it cannot be resolved.
-                              enum:
-                              - Required
-                              - Optional
-                              type: string
-                            resolve:
-                              description: Resolve specifies when this reference should
-                                be resolved. The default is 'IfNotPresent', which
-                                will attempt to resolve the reference only when the
-                                corresponding field is not present. Use 'Always' to
-                                resolve the reference on every reconcile.
-                              enum:
-                              - Always
-                              - IfNotPresent
-                              type: string
-                          type: object
-                      required:
-                      - name
-                      type: object
                     type: array
                   vpcId:
                     description: Specifies the VPC ID for which a route table is to

--- a/pkg/references/references.go
+++ b/pkg/references/references.go
@@ -1,0 +1,51 @@
+package references
+
+import (
+	"github.com/FrangipaneTeam/provider-flexibleengine/pkg/tools"
+)
+
+// TypeVPCSubnet returns a Reference to a VPCSubnet resource.
+// Type is vpc/VPCSubnet, Extractor(true, "id"), RefFieldName: SubnetIDRef, SelectorFieldName: SubnetIDSelector
+func TypeVPCSubnetID() Reference {
+	return Reference{
+		Type:              tools.GenerateType("vpc", "VPCSubnet"),
+		Extractor:         tools.GenerateExtractor(true, "id"),
+		RefFieldName:      "SubnetIDRef",
+		SelectorFieldName: "SubnetIDSelector",
+	}
+}
+
+// TypeVPC returns a Reference to a VPC resource.
+// Type is vpc/VPC
+func TypeVPCID() Reference {
+	return Reference{
+		Type: tools.GenerateType("vpc", "VPC"),
+	}
+}
+
+// TypeSecurityGroup returns a Reference to a SecurityGroup resource.
+// Type is vpc/SecurityGroup, RefFieldName: SecurityGroupIDRef, SelectorFieldName: SecurityGroupIDSelector
+func TypeSecurityGroupID() Reference {
+	return Reference{
+		Type:              tools.GenerateType("vpc", "SecurityGroup"),
+		RefFieldName:      "SecurityGroupIDRef",
+		SelectorFieldName: "SecurityGroupIDSelector",
+	}
+}
+
+// TypeVPCSubnetIDIPV4 returns a Reference to a VPCSubnet resource with extractor for ipv4_subnet_id.
+// Type is vpc/VPCSubnet, Extractor(true, "ipv4_subnet_id")
+func TypeVPCSubnetIDIPV4() Reference {
+	return Reference{
+		Type:      tools.GenerateType("vpc", "VPCSubnet"),
+		Extractor: tools.GenerateExtractor(true, "ipv4_subnet_id"),
+	}
+}
+
+// TypeEIPID returns a Reference to a EIP resource.
+// Type is vpc/EIP
+func TypeEIPID() Reference {
+	return Reference{
+		Type: tools.GenerateType("eip", "EIP"),
+	}
+}

--- a/pkg/references/utils.go
+++ b/pkg/references/utils.go
@@ -1,0 +1,45 @@
+package references
+
+import "github.com/upbound/upjet/pkg/config"
+
+type Reference config.Reference
+type ReferenceFn interface {
+	Get() config.Reference
+}
+
+// Get returns the Reference
+func (r Reference) Get() config.Reference {
+	return config.Reference(r)
+}
+
+// WithCustomRefsSelectors Add custom RefFieldName and SelectorFieldName
+func (r Reference) WithCustomRefsSelectors(refFieldName, selectorFieldName string) Reference {
+	r.RefFieldName = refFieldName
+	r.SelectorFieldName = selectorFieldName
+	return r
+}
+
+// WithCustomExtractor Add custom Extractor
+func (r Reference) WithCustomExtractor(extractor string) Reference {
+	r.Extractor = extractor
+	return r
+}
+
+// WithCustomType Add custom Type
+func (r Reference) WithCustomType(typeName string) Reference {
+	r.Type = typeName
+	return r
+}
+
+// WithoutResSelector Remove SelectorFieldName and RefFieldName
+func (r Reference) WithoutRefsSelectors() Reference {
+	r.RefFieldName = ""
+	r.SelectorFieldName = ""
+	return r
+}
+
+// WithoutExtractor Remove Extractor
+func (r Reference) WithoutExtractor() Reference {
+	r.Extractor = ""
+	return r
+}


### PR DESCRIPTION
### Description of your changes

**refactor(netacl/acl)!:** Refs/Selector field change subnetRefs to subnetIdRefs 
**refactor(vpc/routetable):** Refs/Selector field change subnetsRefs to subnetIdRefs 
**chore:** add func references for standardize Refs/Selector FieldsName

**BREAKING CHANGE: Refs/Selector field change for resources netacl/acl and vpc/routetable**

Fixes #136 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.
