### PR TITLE
chore(cce/mrs/fgs): add deprecated or ignored resources

### DIFF
--- a/config/external_name.go
+++ b/config/external_name.go
@@ -303,10 +303,6 @@ var ExternalNameConfigs = map[string]config.ExternalName{
 	// https://registry.terraform.io/providers/FlexibleEngineCloud/flexibleengine/latest/docs/resources/cce_node_pool_v3
 	"flexibleengine_cce_node_pool_v3": TemplatedStringAsIdentifierWithNoName("{{ .parameters.cluster_id }}/{{ .external_name }}"),
 
-	// flexibleengine_cce_pvc - Imported using {cluster_id}/{namespace}/{name}
-	// https://registry.terraform.io/providers/FlexibleEngineCloud/flexibleengine/latest/docs/resources/cce_pvc
-	"flexibleengine_cce_pvc": TemplatedStringAsIdentifierWithNoName("{{ .parameters.cluster_id }}/{{ .parameters.namespace }}/{{ .external_name }}"),
-
 	// flexibleengine_cce_node_v3 - Imported using the ID
 	// https://registry.terraform.io/providers/FlexibleEngineCloud/flexibleengine/latest/docs/resources/cce_node_v3
 	"flexibleengine_cce_node_v3": config.IdentifierFromProvider,
@@ -734,21 +730,9 @@ var ExternalNameConfigs = map[string]config.ExternalName{
 	/*
 		> MapReduce Service (MRS)
 	*/
-	// flexibleengine_mrs_cluster_v1 - Imported using the ID
-	// https://registry.terraform.io/providers/FlexibleEngineCloud/flexibleengine/latest/docs/resources/mrs_cluster_v1
-	"flexibleengine_mrs_cluster_v1": config.IdentifierFromProvider,
-
 	// flexibleengine_mrs_cluster_v2 - Imported using the ID
 	// https://registry.terraform.io/providers/FlexibleEngineCloud/flexibleengine/latest/docs/resources/mrs_cluster_v2
 	"flexibleengine_mrs_cluster_v2": config.IdentifierFromProvider,
-
-	// flexibleengine_mrs_hybrid_cluster_v1 - Imported using the ID
-	// https://registry.terraform.io/providers/FlexibleEngineCloud/flexibleengine/latest/docs/resources/mrs_hybrid_cluster_v1
-	"flexibleengine_mrs_hybrid_cluster_v1": config.IdentifierFromProvider,
-
-	// flexibleengine_mrs_job_v1 - Imported using the ID
-	// https://registry.terraform.io/providers/FlexibleEngineCloud/flexibleengine/latest/docs/resources/mrs_job_v1
-	"flexibleengine_mrs_job_v1": config.IdentifierFromProvider,
 
 	// flexibleengine_mrs_job_v2 - Imported using template
 	// https://registry.terraform.io/providers/FlexibleEngineCloud/flexibleengine/latest/docs/resources/mrs_job_v2
@@ -818,10 +802,6 @@ var ExternalNameConfigs = map[string]config.ExternalName{
 	// flexibleengine_fgs_function - Imported using the ID
 	// https://registry.terraform.io/providers/FlexibleEngineCloud/flexibleengine/latest/docs/resources/fgs_function
 	"flexibleengine_fgs_function": config.IdentifierFromProvider,
-
-	// flexibleengine_fgs_dependency - Imported using the ID
-	// https://registry.terraform.io/providers/FlexibleEngineCloud/flexibleengine/latest/docs/resources/fgs_dependency
-	"flexibleengine_fgs_dependency": config.IdentifierFromProvider,
 
 	// flexibleengine_fgs_trigger - Imported using the ID
 	// https://registry.terraform.io/providers/FlexibleEngineCloud/flexibleengine/latest/docs/resources/fgs_trigger

--- a/config/externalnamenottested.go
+++ b/config/externalnamenottested.go
@@ -1,0 +1,18 @@
+package config
+
+import (
+	"github.com/upbound/upjet/pkg/config"
+)
+
+// ExternalNameNotTestedConfigs contains no-tested configurations for this
+// provider.
+var ExternalNameNotTestedConfigs = map[string]config.ExternalName{
+
+	// flexibleengine_cce_pvc - Imported using {cluster_id}/{namespace}/{name}
+	// https://registry.terraform.io/providers/FlexibleEngineCloud/flexibleengine/latest/docs/resources/cce_pvc
+	"flexibleengine_cce_pvc": TemplatedStringAsIdentifierWithNoName("{{ .parameters.cluster_id }}/{{ .parameters.namespace }}/{{ .external_name }}"),
+
+	// flexibleengine_fgs_dependency - Imported using the ID
+	// https://registry.terraform.io/providers/FlexibleEngineCloud/flexibleengine/latest/docs/resources/fgs_dependency
+	"flexibleengine_fgs_dependency": config.IdentifierFromProvider,
+}


### PR DESCRIPTION
### Description of your changes

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
```
❯ go run cmd/resources/main.go
Checking resources
=====================================

* Found 196 resources in terraform provider
* Found 166 resources implemented in crossplace provider
* Found 26 resources ignored in crossplace provider

Total 192/196 resources implemented

> 4 resources are not implemented (Add resources to ExternalName):
    + flexibleengine_vpc_route_v2
    + flexibleengine_compute_floatingip_v2
    + flexibleengine_lb_certificate_v2
    + flexibleengine_vpc_eip_v1
```