### PR TITLE
ci: update docs.crds.dev after a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,3 +114,8 @@ jobs:
         env:
           UP_ACCOUNT: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR }}
           UP_TOKEN: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW }}
+      
+      - name: Update docs.crds.dev
+        continue-on-error: true
+        run: |
+          curl -s -X GET "https://doc.crds.dev/github.com/FrangipaneTeam/provider-flexibleengine@${GITHUB_REF##*/}"


### PR DESCRIPTION
Add a simple curl step at the end of the release workflow to call the generation of the docs https://doc.crds.dev/github.com/FrangipaneTeam/provider-flexibleengine@{release}