### PR TITLE
fix: multiple AZ for rocketmqinstances

### DIFF
--- a/examples/dms/rocketmqinstance.yaml
+++ b/examples/dms/rocketmqinstance.yaml
@@ -10,6 +10,7 @@ spec:
   forProvider:
     availabilityZones:
     - eu-west-0a
+    - eu-west-0b
     description: Test rocketmq instance
     engineVersion: 4.8.0
     flavorId: c6.4u8g.cluster


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Flexible Engine provider!
-->

### Description of your changes
Add example with multi AZ for rocketmqinstance
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
```
❯ on ⛵ kind-kind on kind-kind in kind-kind () ❯ k get managed
NAME                                                                           READY   SYNCED   EXTERNAL-NAME                          AGE
rocketmqinstance.dms.flexibleengine.upbound.io/example-dms-rocketmq-instance   True    True     9a46f190-e6cc-40b1-81e7-339b55d333e3   7m59s

NAME                                                           READY   SYNCED   EXTERNAL-NAME                          AGE
securitygroup.vpc.flexibleengine.upbound.io/example-secgroup   True    True     cb1a2359-0c1a-46e2-949c-b71b18f06826   7m59s

NAME                                            READY   SYNCED   EXTERNAL-NAME                          AGE
vpc.vpc.flexibleengine.upbound.io/example-vpc   True    True     eedd2a1b-6d8d-4632-b486-a540f287a68b   7m59s

NAME                                                     READY   SYNCED   EXTERNAL-NAME                          AGE
vpcsubnet.vpc.flexibleengine.upbound.io/example-subnet   True    True     301b8536-10b4-4182-9011-72d0e0965eb7   7m59s
```
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->